### PR TITLE
gocryptox509: generate `results.json`

### DIFF
--- a/harness/gocryptox509/.gitignore
+++ b/harness/gocryptox509/.gitignore
@@ -1,0 +1,1 @@
+results.json

--- a/harness/gocryptox509/main.go
+++ b/harness/gocryptox509/main.go
@@ -10,14 +10,45 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"runtime"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 )
 
+type testcaseResult string
+
+const (
+	validationKindClient = "CLIENT"
+	validationKindServer = "SERVER"
+
+	testcaseFailed  testcaseResult = "FAILURE"
+	testcasePassed  testcaseResult = "SUCCESS"
+	testcaseSkipped testcaseResult = "SKIPPED"
+)
+
+func (r testcaseResult) String() string {
+	s := map[testcaseResult]string{testcaseFailed: "FAIL", testcasePassed: "PASS", testcaseSkipped: "SKIP"}
+	return s[r]
+}
+
+type result struct {
+	ID      string         `json:"id"`
+	Result  testcaseResult `json:"actual_result"`
+	Context string         `json:"context"`
+}
+
+type results struct {
+	Version uint     `json:"version"`
+	Harness string   `json:"harness"`
+	Results []result `json:"results"`
+}
+
 func main() {
 	testCasePath := flag.String("testcases", "../../limbo.json", "testcases")
+	resultsPath := flag.String("results", "./results.json", "results")
 	flag.Parse()
 
 	testcases, err := loadTestcases(*testCasePath)
@@ -26,19 +57,46 @@ func main() {
 	}
 	fmt.Printf("Loaded testcases from %s\n", *testCasePath)
 
-	var success, fail int
+	resultsFile, err := os.Create(*resultsPath)
+	if err != nil {
+		panic(err)
+	}
+	resultsEncoder := json.NewEncoder(resultsFile)
+
+	var (
+		pass, fail, skip int
+		outputResults    results
+	)
 	for _, tc := range testcases.Testcases {
-		fmt.Printf("test id=%s ... ", tc.Id)
-		if err := evaluateTestcase(tc); err != nil {
-			fmt.Printf("fail\n\n%+#v\n\nTest description:\n\n%s\n", err, tc.Description)
+		fmt.Printf("Running test %s ... ", tc.Id)
+		r, err := evaluateTestcase(tc)
+		fmt.Printf("%s\n", r)
+
+		var context string
+		switch r {
+		case testcaseFailed:
+			fmt.Printf("%s\nerr=%+#v\n", tc.Description, err)
+			context = err.Error()
 			fail++
-		} else {
-			fmt.Printf("ok\n")
-			success++
+		case testcasePassed:
+			pass++
+		case testcaseSkipped:
+			skip++
+			continue
 		}
+
+		outputResults.Results = append(outputResults.Results, result{
+			ID:      tc.Id,
+			Context: context,
+			Result:  r,
+		})
 	}
 
-	fmt.Printf("done! succeeded/failed/total %d/%d/%d.\n", success, fail, len(testcases.Testcases))
+	outputResults.Version = 1
+	outputResults.Harness = fmt.Sprintf("gocryptox509-%s", runtime.Version())
+	resultsEncoder.Encode(outputResults)
+
+	fmt.Printf("done! passed/failed/skipped/total %d/%d/%d/%d.\n", pass, fail, skip, len(testcases.Testcases))
 }
 
 func loadTestcases(path string) (testcases LimboSchemaJson, err error) {
@@ -59,15 +117,7 @@ func concatPEMCerts(certs []string) []byte {
 	return buf.Bytes()
 }
 
-const (
-	validationKindClient = "CLIENT"
-	validationKindServer = "SERVER"
-
-	resultSuccess = "SUCCESS"
-	resultFailure = "FAILURE"
-)
-
-func evaluateTestcase(testcase Testcase) error {
+func evaluateTestcase(testcase Testcase) (testcaseResult, error) {
 	_ = spew.Dump
 
 	var ts time.Time
@@ -78,32 +128,35 @@ func evaluateTestcase(testcase Testcase) error {
 		ts, err = time.Parse(time.RFC3339, *testcase.ValidationTime)
 
 		if err != nil {
-			return errors.Wrap(err, "unable to parse testcase time as RFC3339")
+			return testcaseSkipped, errors.Wrap(err, "unable to parse testcase time as RFC3339")
 		}
 	}
 
-	expectSuccess := testcase.ExpectedResult == resultSuccess
+	expectSuccess := testcase.ExpectedResult == testcasePassed
 
 	// TODO: Support testcases that constrain signature algorthms.
 	if len(testcase.SignatureAlgorithms) != 0 {
-		return fmt.Errorf("signature algorithm checks not supported yet")
+		return testcaseSkipped, fmt.Errorf("signature algorithm checks not supported yet")
 	}
 
 	// TODO: Support testcases that constrain key usages.
 	if len(testcase.KeyUsage) != 0 {
-		return fmt.Errorf("key usage checks not supported yet")
+		return testcaseSkipped, fmt.Errorf("key usage checks not supported yet")
 	}
 
 	// TODO: Support testcases that constrain extended key usages.
 	if len(testcase.ExtendedKeyUsage) != 0 {
-		return fmt.Errorf("extended key usage checks not supported yet")
+		return testcaseSkipped, fmt.Errorf("extended key usage checks not supported yet")
 	}
 
 	switch testcase.ValidationKind {
 	case validationKindClient:
-		// TODO: Support testcases that specify the peer's name.
-		if testcase.ExpectedPeerName != nil {
-			return fmt.Errorf("peer name checks not supported yet")
+		var dnsName string
+		if peerName, ok := testcase.ExpectedPeerName.(PeerName); ok {
+			if peerName.Kind.(string) != "DNS" {
+				return testcaseSkipped, fmt.Errorf("non-DNS peer name checks not supported yet")
+			}
+			dnsName = peerName.Value
 		}
 		roots, intermediates := x509.NewCertPool(), x509.NewCertPool()
 		roots.AppendCertsFromPEM(concatPEMCerts(testcase.TrustedCerts))
@@ -111,17 +164,23 @@ func evaluateTestcase(testcase Testcase) error {
 
 		peerAsPEM, rest := pem.Decode([]byte(testcase.PeerCertificate))
 		if peerAsPEM == nil || peerAsPEM.Type != "CERTIFICATE" {
-			return fmt.Errorf("unexpected data, expected cert: %+#v", *peerAsPEM)
+			return testcaseFailed, fmt.Errorf("unexpected data, expected cert: %+#v", *peerAsPEM)
 		} else if len(rest) > 0 {
-			return fmt.Errorf("peer certificate has %d trailing bytes", len(rest))
+			return testcaseFailed, fmt.Errorf("peer certificate has %d trailing bytes", len(rest))
 		}
 
 		peer, err := x509.ParseCertificate(peerAsPEM.Bytes)
 		if err != nil {
-			return errors.Wrap(err, "unable to parse ASN1 certificate from PEM")
+			err = errors.Wrap(err, "unable to parse ASN1 certificate from PEM")
+			if expectSuccess {
+				return testcaseFailed, err
+			} else {
+				return testcasePassed, err
+			}
 		}
 
 		opts := x509.VerifyOptions{
+			DNSName:       dnsName,
 			Intermediates: intermediates,
 			Roots:         roots,
 			CurrentTime:   ts,
@@ -131,13 +190,13 @@ func evaluateTestcase(testcase Testcase) error {
 		_ = chain
 
 		if err != nil && expectSuccess {
-			return errors.Wrap(err, "validation failed when success was expected")
+			return testcaseFailed, errors.Wrap(err, "validation failed when success was expected")
 		} else if err == nil && !expectSuccess {
-			return fmt.Errorf("validation succeeded when failure was expected")
+			return testcaseFailed, fmt.Errorf("validation succeeded when failure was expected")
 		}
 	case validationKindServer:
-		return fmt.Errorf("unimplemented validationKindServer")
+		return testcaseSkipped, fmt.Errorf("unimplemented validationKindServer")
 	}
 
-	return nil
+	return testcasePassed, nil
 }


### PR DESCRIPTION
Refactors `gocryptox509` to generate `results.json` and adds test skipping.