### PR TITLE
refactor in-tree test harnesses

### DIFF
--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -1,4 +1,4 @@
-name: test-harness
+name: Run in-tree test harnesses
 
 on:
   push:
@@ -25,9 +25,7 @@ jobs:
 
       - name: render summary
         run: |
-          python ./harness/render-summary.py \
-            limbo.json \
-            harness/gocryptox509/results.json
+          python ./harness/render-summary.py limbo.json results.json
   openssl:
     runs-on: ubuntu-latest
     steps:
@@ -42,9 +40,7 @@ jobs:
 
       - name: render summary
         run: |
-          python ./harness/render-summary.py \
-            limbo.json \
-            harness/openssl/results.json
+          python ./harness/render-summary.py limbo.json results.json
 
   rust-webpki:
     runs-on: ubuntu-latest
@@ -60,9 +56,7 @@ jobs:
 
       - name: render summary
         run: |
-          python ./harness/render-summary.py \
-            limbo.json \
-            harness/rust-webpki/results.json
+          python ./harness/render-summary.py limbo.json results.json
 
   rustls-webpki:
     runs-on: ubuntu-latest
@@ -78,7 +72,5 @@ jobs:
 
       - name: render summary
         run: |
-          python ./harness/render-summary.py \
-            limbo.json \
-            harness/rust-rustls/results.json
+          python ./harness/render-summary.py limbo.json results.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # rendered HTML
 site_html/
+
+# harness results
+results.json

--- a/Makefile
+++ b/Makefile
@@ -68,19 +68,23 @@ testcases: $(NEEDS_VENV)
 
 .PHONY: test-go
 test-go:
-	$(MAKE) -C harness/gocryptox509 run
+	$(MAKE) -C harness/gocryptox509
+	$(MAKE) run ARGS="harness ./harness/gocryptox509/gocryptox509"
 
 .PHONY: test-openssl
 test-openssl:
-	$(MAKE) -C harness/openssl run
+	$(MAKE) -C harness/openssl
+	$(MAKE) run ARGS="harness ./harness/openssl/main"
 
 .PHONY: test-rust-webpki
 test-rust-webpki:
-	@cargo run --bin rust-webpki-harness
+	@cargo build --bin rust-webpki-harness
+	$(MAKE) run ARGS="harness ./target/debug/rust-webpki-harness"
 
 .PHONY: test-rustls-webpki
 test-rustls-webpki:
-	@cargo run --bin rust-rustls-harness
+	@cargo build --bin rust-rustls-harness
+	$(MAKE) run ARGS="harness ./target/debug/rust-rustls-harness"
 
 .PHONY: test
 test: test-go test-openssl test-rust-webpki test-rustls-webpki

--- a/harness-support/rust/src/lib.rs
+++ b/harness-support/rust/src/lib.rs
@@ -1,11 +1,11 @@
+use std::io::Read;
+
 use models::Limbo;
 
 pub mod models;
 
-// `cargo run` runs from the workspace root, so this is relative to
-// the root.
-const LIMBO_JSON: &str = "limbo.json";
-
 pub fn load_limbo() -> Limbo {
-    serde_json::from_str::<Limbo>(&std::fs::read_to_string(LIMBO_JSON).unwrap()).unwrap()
+    let mut buf = String::new();
+    std::io::stdin().read_to_string(&mut buf).unwrap();
+    serde_json::from_str::<Limbo>(&buf).unwrap()
 }

--- a/harness/README.md
+++ b/harness/README.md
@@ -10,10 +10,17 @@ x509-limbo's own development.
 Each harness should behave as follows:
 
 1. It should be a single binary that takes no inputs or flags;
-1. It should load the current Limbo testcase set
-   (i.e., [../limbo.json](../limbo.json));
-1. It should exit with a non-zero exit code on any harness-specific
-   errors (i.e. failure to parse a testcase, unexpected internal errors);
-1. On success (all testcases evaluated) it should produce a `results.json`
-   output in its harness directory. This file should match the
-   `LimboResult` schema, which is internal to this repository.
+1. It should read a Limbo-formatted testsuite via `stdin`;
+1. It should exit with a non-zero exit code on any harness-specific errors
+   (e.g. unexpected internal errors, not testcase failures);
+1. It *may* log informational or error messages to `stderr`;
+1. It should write a JSON-formatted result summary to `stdout`. The format
+   of this result payload should match the `LimboResult` schema, which
+   is internal to this repository.
+
+In other words, every harness should behave correctly if invoked like
+this:
+
+```bash
+./harness < limbo.json > results.json
+```

--- a/harness/gocryptox509/.gitignore
+++ b/harness/gocryptox509/.gitignore
@@ -1,1 +1,2 @@
+gocryptox509
 results.json

--- a/harness/gocryptox509/Makefile
+++ b/harness/gocryptox509/Makefile
@@ -1,10 +1,5 @@
-.PHONY: all
-all:
-	@echo "Run my targets individually!"
-
-.PHONY: run
-run:
-	go run .
+gocryptox509: main.go schema.go
+	go build
 
 schema.go: ../../limbo-schema.json
 	go generate

--- a/harness/openssl/Makefile
+++ b/harness/openssl/Makefile
@@ -9,10 +9,6 @@ all: main
 debug: CXXFLAGS += -g -fsanitize=address,undefined
 debug: main
 
-.PHONY: run
-run: main
-	./main
-
 .PHONY: clean
 clean:
 	rm -f main

--- a/harness/openssl/main.cpp
+++ b/harness/openssl/main.cpp
@@ -10,9 +10,6 @@
 #include "date.hpp"
 #include "json.hpp"
 
-#define LIMBO_JSON "../../limbo.json"
-#define LIMBO_RESULTS_OUT "./results.json"
-
 using json = nlohmann::json;
 
 static void SK_X509_free(stack_st_X509 *ptr)
@@ -235,8 +232,7 @@ json evaluate_testcase(const json &testcase)
 
 int main()
 {
-    std::ifstream f(LIMBO_JSON);
-    json limbo = json::parse(f);
+    json limbo = json::parse(std::cin);
 
     json results;
     for (auto &testcase : limbo["testcases"])
@@ -249,8 +245,7 @@ int main()
         {"harness", std::string("openssl-") + OPENSSL_VERSION_STR},
         {"results", std::move(results)},
     };
-    std::ofstream o(LIMBO_RESULTS_OUT);
-    o << std::setw(2) << limbo_result << std::endl;
+    std::cout << std::setw(2) << limbo_result << std::endl;
 
     return 0;
 }

--- a/harness/rust-rustls/src/main.rs
+++ b/harness/rust-rustls/src/main.rs
@@ -6,8 +6,6 @@ use limbo_harness_support::{
     models::{Feature, LimboResult, PeerKind, Testcase, TestcaseResult, ValidationKind},
 };
 
-const LIMBO_RESULTS_OUT: &str = "./harness/rust-rustls/results.json";
-
 fn main() {
     let limbo = load_limbo();
 
@@ -22,11 +20,7 @@ fn main() {
         results,
     };
 
-    std::fs::write(
-        LIMBO_RESULTS_OUT,
-        serde_json::to_string_pretty(&result).unwrap(),
-    )
-    .unwrap()
+    serde_json::to_writer_pretty(std::io::stdout(), &result).unwrap();
 }
 
 fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {

--- a/harness/rust-webpki/src/main.rs
+++ b/harness/rust-webpki/src/main.rs
@@ -6,8 +6,6 @@ use limbo_harness_support::{
     models::{Feature, LimboResult, PeerKind, Testcase, TestcaseResult, ValidationKind},
 };
 
-const LIMBO_RESULTS_OUT: &str = "./harness/rust-webpki/results.json";
-
 fn main() {
     let limbo = load_limbo();
 
@@ -22,11 +20,7 @@ fn main() {
         results,
     };
 
-    std::fs::write(
-        LIMBO_RESULTS_OUT,
-        serde_json::to_string_pretty(&result).unwrap(),
-    )
-    .unwrap()
+    serde_json::to_writer_pretty(std::io::stdout(), &result).unwrap();
 }
 
 fn render_err(e: &webpki::ErrorExt) -> String {

--- a/limbo/_cli.py
+++ b/limbo/_cli.py
@@ -7,7 +7,6 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from xml.etree.ElementInclude import include
 
 from pydantic.schema import schema
 


### PR DESCRIPTION
Use stdin and stdout, add filtering, plumb everything through `limbo harness`.

This should make the harnesses slightly more maintainable.