### PR TITLE
add rfc5280::pc, initial noncritical pc test

### DIFF
--- a/harness/gocryptox509/schema.go
+++ b/harness/gocryptox509/schema.go
@@ -6,268 +6,30 @@ import "encoding/json"
 import "fmt"
 import "reflect"
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *SignatureAlgorithm) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_SignatureAlgorithm {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SignatureAlgorithm, v)
-	}
-	*j = SignatureAlgorithm(v)
-	return nil
-}
-
-const KeyUsageDataEncipherment KeyUsage = "dataEncipherment"
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ExpectedResult) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_ExpectedResult {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_ExpectedResult, v)
-	}
-	*j = ExpectedResult(v)
-	return nil
-}
-
-const ExpectedResultSUCCESS ExpectedResult = "SUCCESS"
-
 type ExpectedResult string
+
+const ExpectedResultFAILURE ExpectedResult = "FAILURE"
+const ExpectedResultSUCCESS ExpectedResult = "SUCCESS"
 
 type Feature string
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ValidationKind) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_ValidationKind {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_ValidationKind, v)
-	}
-	*j = ValidationKind(v)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *Feature) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_Feature {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_Feature, v)
-	}
-	*j = Feature(v)
-	return nil
-}
-
 const FeatureHasCertPolicies Feature = "has-cert-policies"
+const FeatureHasPolicyConstraints Feature = "has-policy-constraints"
+const FeatureMaxChainDepth Feature = "max-chain-depth"
+const FeatureNameConstraintDn Feature = "name-constraint-dn"
 const FeatureNoCertPolicies Feature = "no-cert-policies"
 const FeaturePedanticPublicSuffixWildcard Feature = "pedantic-public-suffix-wildcard"
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *PeerKind) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_PeerKind {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_PeerKind, v)
-	}
-	*j = PeerKind(v)
-	return nil
-}
-
+const FeaturePedanticRfc5280 Feature = "pedantic-rfc5280"
+const FeaturePedanticSerialNumber Feature = "pedantic-serial-number"
 const FeaturePedanticWebpki Feature = "pedantic-webpki"
 const FeaturePedanticWebpkiEku Feature = "pedantic-webpki-eku"
-const FeaturePedanticSerialNumber Feature = "pedantic-serial-number"
-const FeatureMaxChainDepth Feature = "max-chain-depth"
-const FeaturePedanticRfc5280 Feature = "pedantic-rfc5280"
 const FeatureRfc5280IncompatibleWithWebpki Feature = "rfc5280-incompatible-with-webpki"
 
 type KeyUsage string
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *Limbo) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["testcases"]; !ok || v == nil {
-		return fmt.Errorf("field testcases in Limbo: required")
-	}
-	if v, ok := raw["version"]; !ok || v == nil {
-		return fmt.Errorf("field version in Limbo: required")
-	}
-	type Plain Limbo
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = Limbo(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *KeyUsage) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_KeyUsage {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_KeyUsage, v)
-	}
-	*j = KeyUsage(v)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *Testcase) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["description"]; !ok || v == nil {
-		return fmt.Errorf("field description in Testcase: required")
-	}
-	if v, ok := raw["expected_peer_names"]; !ok || v == nil {
-		return fmt.Errorf("field expected_peer_names in Testcase: required")
-	}
-	if v, ok := raw["expected_result"]; !ok || v == nil {
-		return fmt.Errorf("field expected_result in Testcase: required")
-	}
-	if v, ok := raw["extended_key_usage"]; !ok || v == nil {
-		return fmt.Errorf("field extended_key_usage in Testcase: required")
-	}
-	if v, ok := raw["id"]; !ok || v == nil {
-		return fmt.Errorf("field id in Testcase: required")
-	}
-	if v, ok := raw["key_usage"]; !ok || v == nil {
-		return fmt.Errorf("field key_usage in Testcase: required")
-	}
-	if v, ok := raw["peer_certificate"]; !ok || v == nil {
-		return fmt.Errorf("field peer_certificate in Testcase: required")
-	}
-	if v, ok := raw["signature_algorithms"]; !ok || v == nil {
-		return fmt.Errorf("field signature_algorithms in Testcase: required")
-	}
-	if v, ok := raw["trusted_certs"]; !ok || v == nil {
-		return fmt.Errorf("field trusted_certs in Testcase: required")
-	}
-	if v, ok := raw["untrusted_intermediates"]; !ok || v == nil {
-		return fmt.Errorf("field untrusted_intermediates in Testcase: required")
-	}
-	if v, ok := raw["validation_kind"]; !ok || v == nil {
-		return fmt.Errorf("field validation_kind in Testcase: required")
-	}
-	type Plain Testcase
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	if v, ok := raw["conflicts_with"]; !ok || v == nil {
-		plain.ConflictsWith = []string{}
-	}
-	if v, ok := raw["features"]; !ok || v == nil {
-		plain.Features = []Feature{}
-	}
-	*j = Testcase(plain)
-	return nil
-}
-
-const KeyUsageContentCommitment KeyUsage = "contentCommitment"
-const FeatureNameConstraintDn Feature = "name-constraint-dn"
-const ExpectedResultFAILURE ExpectedResult = "FAILURE"
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *PeerName) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["kind"]; !ok || v == nil {
-		return fmt.Errorf("field kind in PeerName: required")
-	}
-	if v, ok := raw["value"]; !ok || v == nil {
-		return fmt.Errorf("field value in PeerName: required")
-	}
-	type Plain PeerName
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = PeerName(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *KnownEKUs) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_KnownEKUs {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_KnownEKUs, v)
-	}
-	*j = KnownEKUs(v)
-	return nil
-}
-
 const KeyUsageCRLSign KeyUsage = "cRLSign"
+const KeyUsageContentCommitment KeyUsage = "contentCommitment"
+const KeyUsageDataEncipherment KeyUsage = "dataEncipherment"
 const KeyUsageDecipherOnly KeyUsage = "decipher_only"
 const KeyUsageDigitalSignature KeyUsage = "digitalSignature"
 const KeyUsageEncipherOnly KeyUsage = "encipher_only"
@@ -408,6 +170,7 @@ var enumValues_ExpectedResult = []interface{}{
 	"FAILURE",
 }
 var enumValues_Feature = []interface{}{
+	"has-policy-constraints",
 	"has-cert-policies",
 	"no-cert-policies",
 	"pedantic-public-suffix-wildcard",
@@ -430,6 +193,189 @@ var enumValues_KeyUsage = []interface{}{
 	"encipher_only",
 	"decipher_only",
 }
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *Testcase) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["description"]; !ok || v == nil {
+		return fmt.Errorf("field description in Testcase: required")
+	}
+	if v, ok := raw["expected_peer_names"]; !ok || v == nil {
+		return fmt.Errorf("field expected_peer_names in Testcase: required")
+	}
+	if v, ok := raw["expected_result"]; !ok || v == nil {
+		return fmt.Errorf("field expected_result in Testcase: required")
+	}
+	if v, ok := raw["extended_key_usage"]; !ok || v == nil {
+		return fmt.Errorf("field extended_key_usage in Testcase: required")
+	}
+	if v, ok := raw["id"]; !ok || v == nil {
+		return fmt.Errorf("field id in Testcase: required")
+	}
+	if v, ok := raw["key_usage"]; !ok || v == nil {
+		return fmt.Errorf("field key_usage in Testcase: required")
+	}
+	if v, ok := raw["peer_certificate"]; !ok || v == nil {
+		return fmt.Errorf("field peer_certificate in Testcase: required")
+	}
+	if v, ok := raw["signature_algorithms"]; !ok || v == nil {
+		return fmt.Errorf("field signature_algorithms in Testcase: required")
+	}
+	if v, ok := raw["trusted_certs"]; !ok || v == nil {
+		return fmt.Errorf("field trusted_certs in Testcase: required")
+	}
+	if v, ok := raw["untrusted_intermediates"]; !ok || v == nil {
+		return fmt.Errorf("field untrusted_intermediates in Testcase: required")
+	}
+	if v, ok := raw["validation_kind"]; !ok || v == nil {
+		return fmt.Errorf("field validation_kind in Testcase: required")
+	}
+	type Plain Testcase
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	if v, ok := raw["conflicts_with"]; !ok || v == nil {
+		plain.ConflictsWith = []string{}
+	}
+	if v, ok := raw["features"]; !ok || v == nil {
+		plain.Features = []Feature{}
+	}
+	*j = Testcase(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *PeerName) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["kind"]; !ok || v == nil {
+		return fmt.Errorf("field kind in PeerName: required")
+	}
+	if v, ok := raw["value"]; !ok || v == nil {
+		return fmt.Errorf("field value in PeerName: required")
+	}
+	type Plain PeerName
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = PeerName(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *Limbo) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["testcases"]; !ok || v == nil {
+		return fmt.Errorf("field testcases in Limbo: required")
+	}
+	if v, ok := raw["version"]; !ok || v == nil {
+		return fmt.Errorf("field version in Limbo: required")
+	}
+	type Plain Limbo
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = Limbo(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *Feature) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_Feature {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_Feature, v)
+	}
+	*j = Feature(v)
+	return nil
+}
+
+var enumValues_PeerKind = []interface{}{
+	"RFC822",
+	"DNS",
+	"IP",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *PeerKind) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_PeerKind {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_PeerKind, v)
+	}
+	*j = PeerKind(v)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *KeyUsage) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_KeyUsage {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_KeyUsage, v)
+	}
+	*j = KeyUsage(v)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ExpectedResult) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_ExpectedResult {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_ExpectedResult, v)
+	}
+	*j = ExpectedResult(v)
+	return nil
+}
+
 var enumValues_KnownEKUs = []interface{}{
 	"anyExtendedKeyUsage",
 	"serverAuth",
@@ -439,11 +385,52 @@ var enumValues_KnownEKUs = []interface{}{
 	"timeStamping",
 	"OCSPSigning",
 }
-var enumValues_PeerKind = []interface{}{
-	"RFC822",
-	"DNS",
-	"IP",
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SignatureAlgorithm) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_SignatureAlgorithm {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SignatureAlgorithm, v)
+	}
+	*j = SignatureAlgorithm(v)
+	return nil
 }
+
+var enumValues_ValidationKind = []interface{}{
+	"CLIENT",
+	"SERVER",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ValidationKind) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_ValidationKind {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_ValidationKind, v)
+	}
+	*j = ValidationKind(v)
+	return nil
+}
+
 var enumValues_SignatureAlgorithm = []interface{}{
 	"RSA_WITH_MD5",
 	"RSA_WITH_SHA1",
@@ -476,7 +463,23 @@ var enumValues_SignatureAlgorithm = []interface{}{
 	"GOSTR3410_2012_WITH_3411_2012_256",
 	"GOSTR3410_2012_WITH_3411_2012_512",
 }
-var enumValues_ValidationKind = []interface{}{
-	"CLIENT",
-	"SERVER",
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *KnownEKUs) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_KnownEKUs {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_KnownEKUs, v)
+	}
+	*j = KnownEKUs(v)
+	return nil
 }

--- a/limbo-schema.json
+++ b/limbo-schema.json
@@ -12,6 +12,7 @@
     "Feature": {
       "description": "Feature tags for testcases.",
       "enum": [
+        "has-policy-constraints",
         "has-cert-policies",
         "no-cert-policies",
         "pedantic-public-suffix-wildcard",

--- a/limbo/models.py
+++ b/limbo/models.py
@@ -147,6 +147,11 @@ class Feature(str, Enum):
     Feature tags for testcases.
     """
 
+    has_policy_constraints = "has-policy-constraints"
+    """
+    For implementations that explicitly support policy constraints and policy mapping.
+    """
+
     has_cert_policies = "has-cert-policies"
     """
     For implementations that explicitly support X.509 certificate policy extensions.

--- a/limbo/testcases/_core.py
+++ b/limbo/testcases/_core.py
@@ -45,7 +45,7 @@ class Builder:
         aki: _Extension[x509.AuthorityKeyIdentifier] | Literal[True] | None,
         ski: _Extension[x509.SubjectKeyIdentifier] | Literal[True] | None,
         name_constraints: _Extension[x509.NameConstraints] | None,
-        extra_extension: _Extension[x509.UnrecognizedExtension] | None,
+        extra_extension: _Extension[x509.ExtensionType] | None,
         parent: CertificatePair | None,
     ) -> CertificatePair:
         if subject is None:
@@ -204,7 +204,7 @@ class Builder:
         aki: _Extension[x509.AuthorityKeyIdentifier] | Literal[True] | None = True,
         ski: _Extension[x509.SubjectKeyIdentifier] | Literal[True] | None = True,
         name_constraints: _Extension[x509.NameConstraints] | None = None,
-        extra_extension: _Extension[x509.UnrecognizedExtension] | None = None,
+        extra_extension: _Extension[x509.ExtensionType] | None = None,
     ) -> CertificatePair:
         """
         An intermediate CA chained up to a root CA.

--- a/limbo/testcases/rfc5280/__init__.py
+++ b/limbo/testcases/rfc5280/__init__.py
@@ -13,6 +13,7 @@ from limbo.testcases._core import Builder, testcase
 from .aki import *  # noqa: F403
 from .eku import *  # noqa: F403
 from .nc import *  # noqa: F403
+from .pc import *  # noqa: F403
 from .san import *  # noqa: F403
 from .serial import *  # noqa: F403
 from .ski import *  # noqa: F403

--- a/limbo/testcases/rfc5280/pc.py
+++ b/limbo/testcases/rfc5280/pc.py
@@ -1,0 +1,43 @@
+"""
+RFC 5280 Policy Constraints (PC) testcases.
+"""
+
+from cryptography import x509
+
+from limbo.models import Feature
+from limbo.testcases._core import Builder, ext, testcase
+
+
+@testcase
+def ica_noncritical_pc(builder: Builder) -> None:
+    """
+    Produces the following **invalid** chain:
+
+    ```
+    root -> ICA -> EE
+    ```
+
+    The ICA has a `PolicyConstraints` extension marked as non-critical,
+    which is disallowed under RFC 5280 4.2.1.11:
+
+    > Conforming CAs MUST mark this extension as critical.
+    """
+
+    root = builder.root_ca()
+    ica = builder.intermediate_ca(
+        root,
+        extra_extension=ext(
+            x509.PolicyConstraints(require_explicit_policy=3, inhibit_policy_mapping=None),
+            critical=False,
+        ),
+    )
+    leaf = builder.leaf_cert(ica)
+
+    builder = (
+        builder.server_validation()
+        .features([Feature.has_policy_constraints])
+        .trusted_certs(root)
+        .untrusted_intermediates(ica)
+        .peer_certificate(leaf)
+        .fails()
+    )


### PR DESCRIPTION
This is placed behind a `has-policy-constraints` feature flag, since support for these is essentially nonexistent.