### PR TITLE
webpki: improve pedantic "forbidden leaf key" tests

### DIFF
--- a/harness/gocryptox509/schema.go
+++ b/harness/gocryptox509/schema.go
@@ -21,8 +21,8 @@ const FeatureNoCertPolicies Feature = "no-cert-policies"
 const FeaturePedanticPublicSuffixWildcard Feature = "pedantic-public-suffix-wildcard"
 const FeaturePedanticRfc5280 Feature = "pedantic-rfc5280"
 const FeaturePedanticSerialNumber Feature = "pedantic-serial-number"
-const FeaturePedanticWebpki Feature = "pedantic-webpki"
 const FeaturePedanticWebpkiEku Feature = "pedantic-webpki-eku"
+const FeaturePedanticWebpkiSubscriberKey Feature = "pedantic-webpki-subscriber-key"
 const FeatureRfc5280IncompatibleWithWebpki Feature = "rfc5280-incompatible-with-webpki"
 
 type KeyUsage string
@@ -175,7 +175,7 @@ var enumValues_Feature = []interface{}{
 	"no-cert-policies",
 	"pedantic-public-suffix-wildcard",
 	"name-constraint-dn",
-	"pedantic-webpki",
+	"pedantic-webpki-subscriber-key",
 	"pedantic-webpki-eku",
 	"pedantic-serial-number",
 	"max-chain-depth",

--- a/limbo-schema.json
+++ b/limbo-schema.json
@@ -17,7 +17,7 @@
         "no-cert-policies",
         "pedantic-public-suffix-wildcard",
         "name-constraint-dn",
-        "pedantic-webpki",
+        "pedantic-webpki-subscriber-key",
         "pedantic-webpki-eku",
         "pedantic-serial-number",
         "max-chain-depth",

--- a/limbo/models.py
+++ b/limbo/models.py
@@ -176,7 +176,7 @@ class Feature(str, Enum):
 
     pedantic_webpki_subscriber_key = "pedantic-webpki-subscriber-key"
     """
-    Like `pedantic_webpki`, but specifically for "pedantic" handling of subscriber key types.
+    Tests that exercise "pedantic" handling of subscriber key types under CABF.
 
     Many CABF validators don't enforce the key requirements on subscriber (i.e. leaf, EE)
     certificates. However, the language in CABF 7.1.2.7 implies that subscriber certificates
@@ -185,7 +185,7 @@ class Feature(str, Enum):
 
     pedantic_webpki_eku = "pedantic-webpki-eku"
     """
-    Like `pedantic_webpki`, but specifically for "pedantic" EKU handling under CABF.
+    Tests that exercise "pedantic" EKU handling under CABF.
     """
 
     pedantic_serial_number = "pedantic-serial-number"

--- a/limbo/models.py
+++ b/limbo/models.py
@@ -174,14 +174,18 @@ class Feature(str, Enum):
     For implementations that do not support name constraints for Distinguished Names (temporary).
     """
 
-    pedantic_webpki = "pedantic-webpki"
+    pedantic_webpki_subscriber_key = "pedantic-webpki-subscriber-key"
     """
-    Tests that exercise "pedantic" corners of the CABF profile.
+    Like `pedantic_webpki`, but specifically for "pedantic" handling of subscriber key types.
+
+    Many CABF validators don't enforce the key requirements on subscriber (i.e. leaf, EE)
+    certificates. However, the language in CABF 7.1.2.7 implies that subscriber certificates
+    obey the same `subjectPublicKeyInfo` rules as CAs, as defined in CABF 7.1.3.1.
     """
 
     pedantic_webpki_eku = "pedantic-webpki-eku"
     """
-    Like `pedantic_webpkif`, but specifically for "pedantic" EKU handling under CABF.
+    Like `pedantic_webpki`, but specifically for "pedantic" EKU handling under CABF.
     """
 
     pedantic_serial_number = "pedantic-serial-number"

--- a/limbo/testcases/webpki/__init__.py
+++ b/limbo/testcases/webpki/__init__.py
@@ -90,7 +90,31 @@ def malformed_aia(builder: Builder) -> None:
 
 
 @testcase
-def forbidden_p192_spki_leaf(builder: Builder) -> None:
+def forbidden_p192_root(builder: Builder) -> None:
+    """
+    Produces the following **invalid** chain:
+
+    ```
+    root -> EE
+    ```
+
+    The root cert conveys a P-192 key and signs for the EE with it,
+    which is not permitted under the CABF's key or signature types.
+    """
+
+    root_key = ec.generate_private_key(ec.SECP192R1())
+    root = builder.root_ca(key=root_key)
+
+    leaf = builder.leaf_cert(root)
+
+    builder = builder.server_validation()
+    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
+        PeerName(kind="DNS", value="example.com")
+    ).fails()
+
+
+@testcase
+def forbidden_p192_leaf(builder: Builder) -> None:
     """
     Produces the following **invalid** chain:
 
@@ -114,7 +138,31 @@ def forbidden_p192_spki_leaf(builder: Builder) -> None:
 
 
 @testcase
-def forbidden_dsa_spki_leaf(builder: Builder) -> None:
+def forbidden_dsa_root(builder: Builder) -> None:
+    """
+    Produces the following **invalid** chain:
+
+    ```
+    root -> EE
+    ```
+
+    The root cert conveys a DSA-30272 key and signs for the EE with it,
+    which is not permitted under the CABF's key or signature types.
+    """
+
+    root_key = dsa.generate_private_key(key_size=3072)
+    root = builder.root_ca(key=root_key)
+
+    leaf = builder.leaf_cert(root)
+
+    builder = builder.server_validation()
+    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
+        PeerName(kind="DNS", value="example.com")
+    ).fails()
+
+
+@testcase
+def forbidden_dsa_leaf(builder: Builder) -> None:
     """
     Produces the following **invalid** chain:
 
@@ -132,29 +180,6 @@ def forbidden_dsa_spki_leaf(builder: Builder) -> None:
     leaf = builder.leaf_cert(root, key=leaf_key)
 
     builder = builder.server_validation().features([Feature.pedantic_webpki_subscriber_key])
-    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
-        PeerName(kind="DNS", value="example.com")
-    ).fails()
-
-
-@testcase
-def forbidden_signature_algorithm_in_root(builder: Builder) -> None:
-    """
-    Produces the following **invalid** chain:
-
-    ```
-    root -> EE
-    ```
-
-    The root cert conveys a DSA-3072 key and signs for the leaf with it,
-    which is not one of the permitted signature algorithms under CABF.
-    """
-
-    root_key = dsa.generate_private_key(3072)
-    root = builder.root_ca(key=root_key)
-    leaf = builder.leaf_cert(root)
-
-    builder = builder.server_validation()
     builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
         PeerName(kind="DNS", value="example.com")
     ).fails()
@@ -184,7 +209,7 @@ def forbidden_weak_rsa_key_in_root(builder: Builder) -> None:
 
 
 @testcase
-def forbidden_weak_rsa_key_in_leaf(builder: Builder) -> None:
+def forbidden_weak_rsa_in_leaf(builder: Builder) -> None:
     """
     Produces the following **invalid** chain:
 
@@ -208,7 +233,7 @@ def forbidden_weak_rsa_key_in_leaf(builder: Builder) -> None:
 
 
 @testcase
-def forbidden_rsa_key_not_divisable_by_8_in_root(builder: Builder) -> None:
+def forbidden_rsa_not_divisable_by_8_in_root(builder: Builder) -> None:
     """
     Produces the following **invalid** chain:
 

--- a/limbo/testcases/webpki/__init__.py
+++ b/limbo/testcases/webpki/__init__.py
@@ -98,7 +98,7 @@ def forbidden_p192_spki_leaf(builder: Builder) -> None:
     root -> EE
     ```
 
-    The EE cert contains a P-192 key, which is not one of the permitted
+    The EE cert conveys a P-192 key, which is not one of the permitted
     public keys under CABF.
     """
 
@@ -107,7 +107,7 @@ def forbidden_p192_spki_leaf(builder: Builder) -> None:
     leaf_key = ec.generate_private_key(ec.SECP192R1())
     leaf = builder.leaf_cert(root, key=leaf_key)
 
-    builder = builder.server_validation().features([Feature.pedantic_webpki])
+    builder = builder.server_validation().features([Feature.pedantic_webpki_subscriber_key])
     builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
         PeerName(kind="DNS", value="example.com")
     ).fails()
@@ -131,7 +131,7 @@ def forbidden_dsa_spki_leaf(builder: Builder) -> None:
     leaf_key = dsa.generate_private_key(3072)
     leaf = builder.leaf_cert(root, key=leaf_key)
 
-    builder = builder.server_validation().features([Feature.pedantic_webpki])
+    builder = builder.server_validation().features([Feature.pedantic_webpki_subscriber_key])
     builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
         PeerName(kind="DNS", value="example.com")
     ).fails()
@@ -146,8 +146,8 @@ def forbidden_signature_algorithm_in_root(builder: Builder) -> None:
     root -> EE
     ```
 
-    The root cert is signed with a DSA-3072 key, which is not one of the
-    permitted signature algorithms under CABF.
+    The root cert conveys a DSA-3072 key and signs for the leaf with it,
+    which is not one of the permitted signature algorithms under CABF.
     """
 
     root_key = dsa.generate_private_key(3072)
@@ -155,38 +155,6 @@ def forbidden_signature_algorithm_in_root(builder: Builder) -> None:
     leaf = builder.leaf_cert(root)
 
     builder = builder.server_validation()
-    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
-        PeerName(kind="DNS", value="example.com")
-    ).fails()
-
-
-@testcase
-def forbidden_signature_algorithm_in_leaf(builder: Builder) -> None:
-    """
-    Produces the following **invalid** chain:
-
-    ```
-    root -> EE
-    ```
-
-    The EE cert is signed with a DSA-3072 key, which is not one of the
-    permitted signature algorithms under CABF.
-
-    This case is distinct from `forbidden_signature_algorithm_in_root`,
-    as DSA keys are forbidden in both places but not all implementations
-    check both.
-    """
-
-    root = builder.root_ca()
-
-    leaf_key = dsa.generate_private_key(3072)
-    leaf = builder.leaf_cert(root, key=leaf_key)
-
-    # NOTE: Currently marked as "pedantic" because the correct behavior
-    # here for a path validator is unclear: DSA keys are not allowed
-    # in any certificates under CABF, but path validation logically
-    # does not require checking the EE's key.
-    builder = builder.server_validation().features([Feature.pedantic_webpki])
     builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
         PeerName(kind="DNS", value="example.com")
     ).fails()
@@ -233,8 +201,7 @@ def forbidden_weak_rsa_key_in_leaf(builder: Builder) -> None:
     leaf_key = rsa.generate_private_key(public_exponent=65537, key_size=1024)
     leaf = builder.leaf_cert(root, key=leaf_key)
 
-    # NOTE: Currently marked as "pedantic" for the same reason as `forbidden_dsa_spki_leaf`.
-    builder = builder.server_validation().features([Feature.pedantic_webpki])
+    builder = builder.server_validation().features([Feature.pedantic_webpki_subscriber_key])
     builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
         PeerName(kind="DNS", value="example.com")
     ).fails()
@@ -259,6 +226,30 @@ def forbidden_rsa_key_not_divisable_by_8_in_root(builder: Builder) -> None:
     leaf = builder.leaf_cert(root)
 
     builder = builder.server_validation()
+    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
+        PeerName(kind="DNS", value="example.com")
+    ).fails()
+
+
+@testcase
+def forbidden_rsa_key_not_divisable_by_8_in_leaf(builder: Builder) -> None:
+    """
+    Produces the following **invalid** chain:
+
+    ```
+    root -> EE
+    ```
+
+    The EE cert conveys an RSA-2052 key, which is above the security margin
+    (2048) but not divisible by 8, as is required under CABF 6.1.5.
+    """
+
+    root = builder.root_ca()
+
+    leaf_key = rsa.generate_private_key(public_exponent=65537, key_size=2052)
+    leaf = builder.leaf_cert(root, key=leaf_key)
+
+    builder = builder.server_validation().features([Feature.pedantic_webpki_subscriber_key])
     builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
         PeerName(kind="DNS", value="example.com")
     ).fails()


### PR DESCRIPTION
Following #184, this expands upon the existing pedantic WebPKI tests for leafs with forbidden keys:

* Forbidden RSA leaf (below security margin)
* Forbidden RSA leaf (modulus not divisible by 8)

It also removes a duplicate test (`forbidden_signature_algorithm_in_leaf`).