### PR TITLE
fixup peer_certificate_key in Go schema

### DIFF
--- a/harness/gocryptox509/schema.go
+++ b/harness/gocryptox509/schema.go
@@ -144,6 +144,9 @@ type Testcase struct {
 	// The PEM-encoded peer (EE) certificate
 	PeerCertificate string `json:"peer_certificate" yaml:"peer_certificate" mapstructure:"peer_certificate"`
 
+	// The PEM-encoded private key for the peer certificate, if present
+	PeerCertificateKey interface{} `json:"peer_certificate_key,omitempty" yaml:"peer_certificate_key,omitempty" mapstructure:"peer_certificate_key,omitempty"`
+
 	// A list of acceptable signature algorithms to constrain against
 	SignatureAlgorithms []SignatureAlgorithm `json:"signature_algorithms" yaml:"signature_algorithms" mapstructure:"signature_algorithms"`
 

--- a/limbo-schema.json
+++ b/limbo-schema.json
@@ -223,6 +223,7 @@
               "type": "null"
             }
           ],
+          "default": null,
           "description": "The PEM-encoded private key for the peer certificate, if present",
           "title": "Peer Certificate Key"
         },
@@ -313,7 +314,6 @@
         "trusted_certs",
         "untrusted_intermediates",
         "peer_certificate",
-        "peer_certificate_key",
         "signature_algorithms",
         "key_usage",
         "extended_key_usage",

--- a/limbo/models.py
+++ b/limbo/models.py
@@ -256,7 +256,7 @@ class Testcase(BaseModel):
     peer_certificate: StrictStr = Field(..., description="The PEM-encoded peer (EE) certificate")
 
     peer_certificate_key: StrictStr | None = Field(
-        ...,
+        None,
         description="The PEM-encoded private key for the peer certificate, if present",
     )
 


### PR DESCRIPTION
Fixes a crash caused by a stale generated `schema.go`. I need to determine an appropriate CI check for keeping `schema.go` fresh.

Ref: https://github.com/golang/go/issues/65085