### PR TITLE
ci: enforce schema.go's updatedness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,20 @@ jobs:
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
-      - name: regenerate schema
-        run: make limbo-schema.json
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ">=1.20.5"
 
       - name: fail if the schema has changed
         run: |
+          make limbo-schema.json
           git diff --exit-code -- limbo-schema.json
+
+      - name: fail if schema.go has changed
+        run: |
+          make -C harness/gocryptox509 schema.go
+          git diff --exit-code -- harness/gocryptox509/schema.go
+
 
   check-harnesses:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should reduce the likelihood of regressions like #193.