### PR TITLE
limbo: don't mark SAN as critical when subject is nonempty

### DIFF
--- a/limbo/testcases/pathological.py
+++ b/limbo/testcases/pathological.py
@@ -330,7 +330,7 @@ def nc_dos_1(builder: Builder) -> None:
     leaf = builder.leaf_cert(
         root,
         subject=x509.Name(subjects),
-        san=ext(x509.SubjectAlternativeName(permitteds), critical=True),
+        san=ext(x509.SubjectAlternativeName(permitteds), critical=False),
     )
 
     builder = (


### PR DESCRIPTION
This was causing an upstream failure for an unrelated reason (per CABF, SAN should only be critical if the Subject DN is an empty sequence).