### PR TITLE
add rfc5280::root-and-intermediate-swapped

### DIFF
--- a/limbo/testcases/rfc5280/__init__.py
+++ b/limbo/testcases/rfc5280/__init__.py
@@ -625,3 +625,31 @@ def ca_as_leaf_wrong_san(builder: Builder) -> None:
         .expected_peer_name(PeerName(kind="DNS", value="some-other-ca.example.com"))
         .fails()
     )
+
+
+@testcase
+def root_and_intermediate_swapped(builder: Builder) -> None:
+    """
+    Produces the following valid chain, in an **invalid** configuration:
+
+    ```
+    root -> ICA -> EE
+    ```
+
+    The configuration puts ICA in the trusted set and root in the untrusted set,
+    meaning that no valid path exists to a root of trust despite all constituent
+    members being present.
+    """
+
+    root = builder.root_ca()
+    ica = builder.intermediate_ca(root)
+    leaf = builder.leaf_cert(ica)
+
+    builder = (
+        builder.server_validation()
+        .trusted_certs(ica)
+        .untrusted_intermediates(root)
+        .peer_certificate(leaf)
+        .expected_peer_name(PeerName(kind="DNS", value="example.com"))
+        .fails()
+    )

--- a/limbo/testcases/rfc5280/__init__.py
+++ b/limbo/testcases/rfc5280/__init__.py
@@ -630,15 +630,14 @@ def ca_as_leaf_wrong_san(builder: Builder) -> None:
 @testcase
 def root_and_intermediate_swapped(builder: Builder) -> None:
     """
-    Produces the following valid chain, in an **invalid** configuration:
+    Produces the following valid chain:
 
     ```
     root -> ICA -> EE
     ```
 
-    The configuration puts ICA in the trusted set and root in the untrusted set,
-    meaning that no valid path exists to a root of trust despite all constituent
-    members being present.
+    The configuration puts the ICA in the trusted set, meaning that validation
+    should ignore (and not fail on) the root in the untrusted intermediate set.
     """
 
     root = builder.root_ca()
@@ -651,5 +650,5 @@ def root_and_intermediate_swapped(builder: Builder) -> None:
         .untrusted_intermediates(root)
         .peer_certificate(leaf)
         .expected_peer_name(PeerName(kind="DNS", value="example.com"))
-        .fails()
+        .succeeds()
     )


### PR DESCRIPTION
Realized we didn't have a "swapped root and intermediates" case.