### PR TITLE
harness: add certvalidator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,10 @@ test-rustls-webpki:
 test-pyca-cryptography: $(NEEDS_VENV)
 	$(MAKE) run ARGS="harness --output ./results/pyca-cryptography.json -- ./$(VENV_BIN)/python ./harness/pyca-cryptography/main.py"
 
+.PHONY: test-certvalidator
+test-certvalidator: $(NEEDS_VENV)
+	$(MAKE) run ARGS="harness --output ./results/certvalidator.json -- ./$(VENV_BIN)/python ./harness/certvalidator/main.py"
+
 .PHONY: test
 test: test-go test-openssl test-rust-webpki test-rustls-webpki test-pyca-cryptography
 

--- a/harness/certvalidator/main.py
+++ b/harness/certvalidator/main.py
@@ -1,5 +1,4 @@
 import sys
-from cgi import test
 from concurrent.futures import ThreadPoolExecutor
 
 from certvalidator import CertificateValidator, ValidationContext
@@ -8,8 +7,6 @@ from certvalidator.validate import validate_usage
 
 from limbo.models import (
     ActualResult,
-    KeyUsage,
-    KnownEKUs,
     Limbo,
     LimboResult,
     Testcase,

--- a/harness/certvalidator/main.py
+++ b/harness/certvalidator/main.py
@@ -1,0 +1,103 @@
+import sys
+from cgi import test
+from concurrent.futures import ThreadPoolExecutor
+
+from certvalidator import CertificateValidator, ValidationContext
+from certvalidator import __version__ as version
+from certvalidator.validate import validate_usage
+
+from limbo.models import (
+    ActualResult,
+    KeyUsage,
+    KnownEKUs,
+    Limbo,
+    LimboResult,
+    Testcase,
+    TestcaseResult,
+    ValidationKind,
+)
+
+LIMBO_UNSUPPORTED_FEATURES = set()
+
+LIMBO_SKIP_TESTCASES = set()
+
+
+def _skip(tc: Testcase, msg: str) -> TestcaseResult:
+    return TestcaseResult(id=tc.id, actual_result=ActualResult.SKIPPED, context=msg)
+
+
+def evaluate_testcase(testcase: Testcase) -> TestcaseResult:
+    if testcase.id in LIMBO_SKIP_TESTCASES:
+        return _skip(testcase, "testcase skipped (explicitly unsupported case)")
+
+    if LIMBO_UNSUPPORTED_FEATURES.intersection(testcase.features):
+        return _skip(testcase, "testcase skipped (explicit unsupported feature)")
+
+    if testcase.validation_kind != ValidationKind.SERVER:
+        return _skip(testcase, "non-SERVER cases not supported yet")
+
+    if testcase.signature_algorithms != []:
+        return _skip(testcase, "signature algorithm customization not supported yet")
+
+    context = ValidationContext(
+        trust_roots=[c.encode() for c in testcase.trusted_certs],
+        moment=testcase.validation_time,
+        allow_fetching=False,
+        weak_hash_algos={"md2", "md5", "sha1"},
+    )
+
+    validator = CertificateValidator(
+        end_entity_cert=testcase.peer_certificate.encode(),
+        intermediate_certs=[c.encode() for c in testcase.untrusted_intermediates],
+        validation_context=context,
+    )
+
+    try:
+        path = validator.validate_tls(hostname=testcase.expected_peer_name.value)
+        leaf = list(path)[-1]
+
+        key_usage = {ku.name for ku in testcase.key_usage}
+        extended_key_usage = {eku.name for eku in testcase.extended_key_usage}
+        validate_usage(
+            context,
+            leaf,
+            key_usage=key_usage,
+            extended_key_usage=extended_key_usage,
+            # EKU is required if EKUs are explicitly specified.
+            extended_optional=bool(extended_key_usage),
+        )
+        return TestcaseResult(id=testcase.id, actual_result=ActualResult.SUCCESS, context=None)
+    except Exception as e:  # noqa
+        # NOTE: Ideally we'd catch only certvalidator errors here, but lots of others
+        # leak through (e.g. ValueError and errors from oscrypto).
+        return TestcaseResult(id=testcase.id, actual_result=ActualResult.FAILURE, context=str(e))
+
+
+def main():
+    limbo = Limbo.model_validate_json(sys.stdin.read())
+
+    results: list[TestcaseResult] = []
+    for testcase in limbo.testcases:
+        # NOTE: This is not for true parallelism, just a way to give us cancellation.
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            fut = executor.submit(evaluate_testcase, testcase)
+            try:
+                # Certificate validation should, extremely conservatively,
+                # absolutely never take more than 5 seconds.
+                result = fut.result(timeout=5)
+            except TimeoutError:
+                # NOTE: We need a better result type here.
+                result = TestcaseResult(
+                    id=testcase.id, actual_result=ActualResult.SKIPPED, context="testcase timed out"
+                )
+        results.append(result)
+
+    print(
+        LimboResult(version=1, harness=f"certvalidator-{version}", results=results).model_dump_json(
+            indent=2
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/gocryptox509/schema.go
+++ b/harness/gocryptox509/schema.go
@@ -26,7 +26,7 @@ func (j *SignatureAlgorithm) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-const KeyUsageDecipherOnly KeyUsage = "decipher_only"
+const KeyUsageDecipherOnly KeyUsage = "decipherOnly"
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *ExpectedResult) UnmarshalJSON(b []byte) error {
@@ -328,7 +328,7 @@ const SignatureAlgorithmECDSAWITHSHA224 SignatureAlgorithm = "ECDSA_WITH_SHA224"
 type KnownEKUs string
 
 const SignatureAlgorithmDSAWITHSHA256 SignatureAlgorithm = "DSA_WITH_SHA256"
-const KeyUsageEncipherOnly KeyUsage = "encipher_only"
+const KeyUsageEncipherOnly KeyUsage = "encipherOnly"
 const SignatureAlgorithmECDSAWITHSHA3224 SignatureAlgorithm = "ECDSA_WITH_SHA3_224"
 const SignatureAlgorithmECDSAWITHSHA3256 SignatureAlgorithm = "ECDSA_WITH_SHA3_256"
 const SignatureAlgorithmECDSAWITHSHA3384 SignatureAlgorithm = "ECDSA_WITH_SHA3_384"
@@ -438,8 +438,8 @@ var enumValues_KeyUsage = []interface{}{
 	"keyAgreement",
 	"keyCertSign",
 	"cRLSign",
-	"encipher_only",
-	"decipher_only",
+	"encipherOnly",
+	"decipherOnly",
 }
 var enumValues_KnownEKUs = []interface{}{
 	"anyExtendedKeyUsage",

--- a/limbo-schema.json
+++ b/limbo-schema.json
@@ -38,8 +38,8 @@
         "keyAgreement",
         "keyCertSign",
         "cRLSign",
-        "encipher_only",
-        "decipher_only"
+        "encipherOnly",
+        "decipherOnly"
       ],
       "title": "KeyUsage",
       "type": "string"

--- a/limbo/models.py
+++ b/limbo/models.py
@@ -108,8 +108,8 @@ class KeyUsage(str, Enum):
     key_agreement = "keyAgreement"
     key_cert_sign = "keyCertSign"
     crl_sign = "cRLSign"
-    encipher_only = "encipher_only"
-    decipher_only = "decipher_only"
+    encipher_only = "encipherOnly"
+    decipher_only = "decipherOnly"
 
 
 class KnownEKUs(str, Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ authors = [
 ]
 dependencies = [
     "pydantic ~= 2.4",
+    # For the `certvalidator` test harness.
+    "certvalidator ~= 0.11",
     "cryptography ~= 42.0",
     "pyyaml ~= 6.0",
     "pyOpenSSL",


### PR DESCRIPTION
Some thoughts:

* `certvalidator` depends on `oscrypto`, so these tests might vary by OS. It might make sense to add the OS name into the harness identifier.
* The NC DoS tess grind the harness to a crawl. I've added a timeout, but it's still serial rather than parallel.