### PR TITLE
limbo: fixup docstrings

### DIFF
--- a/limbo/testcases/webpki/san.py
+++ b/limbo/testcases/webpki/san.py
@@ -62,8 +62,8 @@ def mismatch_domain_san(builder: Builder) -> None:
     """
     Produces a chain with an EE cert.
 
-    This EE cert contains a Subject Alternative Name with the dNSName "example.com".
-    This should **fail to verify** against the domain "example2.com", per RFC 6125 6.4.1.
+    This EE cert contains a Subject Alternative Name with the dNSName `example.com`.
+    This should **fail to verify** against the domain `example2.com`, per RFC 6125 6.4.1.
 
     > Each label MUST match in order for the names to be considered to match,
     > except as supplemented by the rule about checking of wildcard labels.
@@ -85,8 +85,8 @@ def mismatch_subdomain_san(builder: Builder) -> None:
     """
     Produces a chain with an EE cert.
 
-    This EE cert contains a Subject Alternative Name with the dNSName "abc.example.com".
-    This should **fail to verify** against the domain "def.example.com", per RFC 6125 6.4.1.
+    This EE cert contains a Subject Alternative Name with the dNSName `abc.example.com`.
+    This should **fail to verify** against the domain `def.example.com`, per RFC 6125 6.4.1.
 
     > Each label MUST match in order for the names to be considered to match,
     > except as supplemented by the rule about checking of wildcard labels.
@@ -109,8 +109,8 @@ def mismatch_subdomain_apex_san(builder: Builder) -> None:
     """
     Produces a chain with an EE cert.
 
-    This EE cert contains a Subject Alternative Name with the dNSName "example.com".
-    This should **fail to verify** against the domain "abc.example.com", per RFC 6125 6.4.1.
+    This EE cert contains a Subject Alternative Name with the dNSName `example.com`.
+    This should **fail to verify** against the domain `abc.example.com`, per RFC 6125 6.4.1.
 
     > Each label MUST match in order for the names to be considered to match,
     > except as supplemented by the rule about checking of wildcard labels.
@@ -132,8 +132,8 @@ def mismatch_apex_subdomain_san(builder: Builder) -> None:
     """
     Produces a chain with an EE cert.
 
-    This EE cert contains a Subject Alternative Name with the dNSName "abc.example.com".
-    This should **fail to verify** against the domain "example.com", per RFC 6125 6.4.1.
+    This EE cert contains a Subject Alternative Name with the dNSName `abc.example.com`.
+    This should **fail to verify** against the domain `example.com`, per RFC 6125 6.4.1.
 
     > Each label MUST match in order for the names to be considered to match,
     > except as supplemented by the rule about checking of wildcard labels.
@@ -155,7 +155,7 @@ def public_suffix_wildcard_san(builder: Builder) -> None:
     """
     Produces a chain with an EE cert.
 
-    This EE cert contains a Subject Alternative name with the dNSName "*.com".
+    This EE cert contains a Subject Alternative name with the dNSName `*.com`.
     Conformant CAs should not issue such a certificate, according to CABF:
 
     > If the FQDN portion of any Wildcard Domain Name is “registry‐controlled”
@@ -183,8 +183,8 @@ def leftmost_wildcard_san(builder: Builder) -> None:
     """
     Produces a chain with an EE cert.
 
-    This EE cert contains a Subject Alternative Name with the dNSName "*.example.com".
-    This should verify successfully against the domain "foo.example.com", per RFC 6125 6.4.3.
+    This EE cert contains a Subject Alternative Name with the dNSName `*.example.com`.
+    This should verify successfully against the domain `foo.example.com`, per RFC 6125 6.4.3.
     """
 
     root = builder.root_ca()
@@ -205,8 +205,8 @@ def wildcard_embedded_leftmost_san(builder: Builder) -> None:
     """
     Produces a chain with an EE cert.
 
-    This EE cert contains a Subject Alternative Name with the dNSName "ba*.example.com".
-    This should **fail to verify** against the domain "baz.example.com", per CABF.
+    This EE cert contains a Subject Alternative Name with the dNSName `ba*.example.com`.
+    This should **fail to verify** against the domain `baz.example.com`, per CABF.
 
     > Wildcard Domain Name: A string starting with “*.” (U+002A ASTERISK, U+002E FULL STOP)
     > immediately followed by a Fully-Qualified Domain Name.
@@ -231,8 +231,8 @@ def wildcard_not_in_leftmost_san(builder: Builder) -> None:
     """
     Produces a chain with an EE cert.
 
-    This EE cert contains a Subject Alternative Name with the dNSName "foo.*.example.com".
-    This should **fail to verify** against the domain "foo.bar.example.com", per RFC 6125 6.4.3.
+    This EE cert contains a Subject Alternative Name with the dNSName `foo.*.example.com`.
+    This should **fail to verify** against the domain `foo.bar.example.com`, per RFC 6125 6.4.3.
 
     > The client SHOULD NOT attempt to match a presented identifier in
     > which the wildcard character comprises a label other than the
@@ -257,8 +257,8 @@ def wildcard_match_across_labels_san(builder: Builder) -> None:
     """
     Produces a chain with an EE cert.
 
-    This EE cert contains a Subject Alternative Name with the dNSName "*.example.com".
-    This should **fail to verify** against the domain "foo.bar.example.com", per RFC 6125 6.4.3.
+    This EE cert contains a Subject Alternative Name with the dNSName `*.example.com`.
+    This should **fail to verify** against the domain `foo.bar.example.com`, per RFC 6125 6.4.3.
 
     > If the wildcard character is the only character of the left-most
     > label in the presented identifier, the client SHOULD NOT compare
@@ -286,8 +286,8 @@ def wildcard_embedded_ulabel_san(builder: Builder) -> None:
     Produces a chain with an EE cert.
 
     This EE cert contains a Subject Alternative Name with the dNSName
-    "xn--*-1b3c148a.example.com". This should **fail to verify** against the domain
-    "xn--bliss-1b3c148a.example.com", per RFC 6125 6.4.3:
+    `xn--*-1b3c148a.example.com`. This should **fail to verify** against the domain
+    `xn--bliss-1b3c148a.example.com`, per RFC 6125 6.4.3:
 
     > ... the client SHOULD NOT attempt to match a presented identifier
     > where the wildcard character is embedded within an A-label or
@@ -315,8 +315,8 @@ def unicode_emoji_san(builder: Builder) -> None:
     """
     Produces a chain with an EE cert.
 
-    This EE cert contains a Subject Alternative Name with the dNSName "😜.example.com",
-    This should **fail to verify** against the domain "xn--628h.example.com",
+    This EE cert contains a Subject Alternative Name with the dNSName `😜.example.com`,
+    This should **fail to verify** against the domain `xn--628h.example.com`,
     per RFC 5280 7.2:
 
     > IA5String is limited to the set of ASCII characters.  To accommodate


### PR DESCRIPTION
Improves the formatting in a few places and avoids broken Markdown.