### PR TITLE
mkdocs, site: make rendered tables sortable

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,9 @@ markdown_extensions:
       permalink: 🔗
 extra_css:
   - style.css
+extra_javascript:
+  - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js
+  - js/tablesort.js
 exclude_docs: |
   render-testcases.py
 validation:

--- a/site/js/tablesort.js
+++ b/site/js/tablesort.js
@@ -1,0 +1,6 @@
+document$.subscribe(function () {
+    var tables = document.querySelectorAll("article table:not([class])")
+    tables.forEach(function (table) {
+        new Tablesort(table)
+    })
+})


### PR DESCRIPTION
Per <https://squidfunk.github.io/mkdocs-material/reference/data-tables/#sortable-tables>.