### PR TITLE
rfc5280/nc: fixup client auth EKUs

### DIFF
--- a/limbo/testcases/rfc5280/nc.py
+++ b/limbo/testcases/rfc5280/nc.py
@@ -8,7 +8,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives.asymmetric import ec
 
 from limbo.assets import ext
-from limbo.models import Feature, PeerName
+from limbo.models import Feature, KnownEKUs, PeerName
 from limbo.testcases._core import Builder, testcase
 
 
@@ -934,6 +934,7 @@ def invalid_email_address(builder: Builder) -> None:
 
     builder = (
         builder.client_validation()
+        .extended_key_usage([KnownEKUs.client_auth])
         .trusted_certs(root)
         .peer_certificate(leaf)
         .expected_peer_names(PeerName(kind="RFC822", value="example@example.com"))
@@ -1379,6 +1380,7 @@ def nc_permits_invalid_email_san(builder: Builder) -> None:
 
     builder = (
         builder.client_validation()
+        .extended_key_usage([KnownEKUs.client_auth])
         .trusted_certs(root)
         .untrusted_intermediates(intermediate)
         .peer_certificate(leaf)
@@ -1558,6 +1560,7 @@ def nc_permits_email_exact(builder: Builder) -> None:
 
     builder = (
         builder.client_validation()
+        .extended_key_usage([KnownEKUs.client_auth])
         .trusted_certs(root)
         .untrusted_intermediates(ica)
         .peer_certificate(leaf)
@@ -1601,6 +1604,7 @@ def nc_permits_email_domain(builder: Builder) -> None:
 
     builder = (
         builder.client_validation()
+        .extended_key_usage([KnownEKUs.client_auth])
         .trusted_certs(root)
         .untrusted_intermediates(ica)
         .peer_certificate(leaf)

--- a/limbo/testcases/rfc5280/nc.py
+++ b/limbo/testcases/rfc5280/nc.py
@@ -926,6 +926,10 @@ def invalid_email_address(builder: Builder) -> None:
         san=ext(
             x509.SubjectAlternativeName([x509.RFC822Name("example@example.com")]), critical=False
         ),
+        eku=ext(
+            x509.ExtendedKeyUsage([x509.OID_CLIENT_AUTH]),
+            critical=False,
+        ),
     )
 
     builder = (
@@ -1367,6 +1371,10 @@ def nc_permits_invalid_email_san(builder: Builder) -> None:
             ),
             critical=False,
         ),
+        eku=ext(
+            x509.ExtendedKeyUsage([x509.OID_CLIENT_AUTH]),
+            critical=False,
+        ),
     )
 
     builder = (
@@ -1542,6 +1550,10 @@ def nc_permits_email_exact(builder: Builder) -> None:
     leaf = builder.leaf_cert(
         ica,
         san=ext(x509.SubjectAlternativeName([x509.RFC822Name("foo@example.com")]), critical=False),
+        eku=ext(
+            x509.ExtendedKeyUsage([x509.OID_CLIENT_AUTH]),
+            critical=False,
+        ),
     )
 
     builder = (
@@ -1581,6 +1593,10 @@ def nc_permits_email_domain(builder: Builder) -> None:
     leaf = builder.leaf_cert(
         ica,
         san=ext(x509.SubjectAlternativeName([x509.RFC822Name("foo@example.com")]), critical=False),
+        eku=ext(
+            x509.ExtendedKeyUsage([x509.OID_CLIENT_AUTH]),
+            critical=False,
+        ),
     )
 
     builder = (


### PR DESCRIPTION
These testcases are currently skipped so I missed this mistake: these should fail or pass for various NC reasons, but were otherwise invalid because they were missing the `clientAuth` EKU.

h/t @jvdprng