### PR TITLE
limbo:proxy stderr of the harness

### DIFF
--- a/limbo/_cli.py
+++ b/limbo/_cli.py
@@ -177,6 +177,7 @@ def _harness(args: argparse.Namespace) -> None:
         result = subprocess.run(
             args.harness, input=limbo_json, encoding="utf-8", capture_output=True, check=True
         )
+        print(result.stderr, file=sys.stderr)
         args.output.write_text(result.stdout)
     except subprocess.CalledProcessError as e:
         print(e.stderr, file=sys.stderr)


### PR DESCRIPTION
When the harness run, it's sometimes convenient to get logs back. Before this commit, stderr was thrown away unless the harness errored out.