### PR TITLE
limbo: add rfc5280::eku::ee-eku-empty

### DIFF
--- a/limbo/testcases/bettertls.py
+++ b/limbo/testcases/bettertls.py
@@ -60,14 +60,10 @@ def _bettertls_testcase(id_: str, root: Certificate, testcase: dict) -> Testcase
     if "INVALID_REASON_EXPIRED" in testcase["requiredFeatures"] and expected == "REJECT":
         # If the testcase is explicitly exercising expiry logic, set our
         # validation time to something that must fail.
-        validation_time = leaf.cert.not_valid_after.replace(tzinfo=timezone.utc) + timedelta(
-            seconds=1
-        )
+        validation_time = leaf.cert.not_valid_after_utc + timedelta(seconds=1)
     else:
         # Otherwise, pick a validation time that should be valid for the whole chain.
-        validation_time = leaf.cert.not_valid_before.replace(tzinfo=timezone.utc) + timedelta(
-            seconds=1
-        )
+        validation_time = leaf.cert.not_valid_before_utc + timedelta(seconds=1)
 
     builder = (
         builder.server_validation()

--- a/limbo/testcases/bettertls.py
+++ b/limbo/testcases/bettertls.py
@@ -11,7 +11,7 @@ import functools
 import ipaddress
 import json
 import logging
-from datetime import timedelta, timezone
+from datetime import timedelta
 
 from cryptography import x509
 

--- a/limbo/testcases/rfc5280/eku.py
+++ b/limbo/testcases/rfc5280/eku.py
@@ -95,7 +95,6 @@ def ee_eku_empty(builder: Builder) -> None:
     builder = builder.server_validation()
     builder = (
         builder.trusted_certs(root)
-        .extended_key_usage([KnownEKUs.server_auth])
         .peer_certificate(leaf)
         .expected_peer_name(PeerName(kind="DNS", value="example.com"))
         .fails()

--- a/limbo/testcases/rfc5280/eku.py
+++ b/limbo/testcases/rfc5280/eku.py
@@ -65,3 +65,38 @@ def ee_without_eku(builder: Builder) -> None:
         .peer_certificate(leaf)
         .succeeds()
     )
+
+
+@testcase
+def ee_eku_empty(builder: Builder) -> None:
+    """
+    Produces the following **invalid** chain:
+
+    ```
+    root -> EE
+    ```
+
+    The EE contains an extKeyUsage extension, but with no listed usages,
+    which is forbidden per RFC 5280 4.2.1.12:
+
+    > This extension indicates one or more purposes for which the certified
+    > public key may be used
+    """
+
+    root = builder.root_ca()
+    leaf = builder.leaf_cert(
+        root,
+        eku=ext(
+            x509.ExtendedKeyUsage([]),
+            critical=False,
+        ),
+    )
+
+    builder = builder.server_validation()
+    builder = (
+        builder.trusted_certs(root)
+        .extended_key_usage([KnownEKUs.server_auth])
+        .peer_certificate(leaf)
+        .expected_peer_name(PeerName(kind="DNS", value="example.com"))
+        .fails()
+    )


### PR DESCRIPTION
Adds a testcase for a present-but-empty EKU extension, which is invalid per RFC 5280.