### PR TITLE
chore: fixup rustls-webpki API usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "chrono",
  "limbo-harness-support",
  "pem",
+ "rustls-pki-types",
  "rustls-webpki",
  "serde_json",
 ]

--- a/harness-support/rust/src/models.rs
+++ b/harness-support/rust/src/models.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use typify::import_types;
 
 import_types!(schema = "../../limbo-schema.json");

--- a/harness/gocryptox509/main.go
+++ b/harness/gocryptox509/main.go
@@ -1,6 +1,6 @@
 package main
 
-//go:generate go run github.com/atombender/go-jsonschema@latest -v -p main -o schema.go ../../limbo-schema.json
+//go:generate go run github.com/atombender/go-jsonschema@v0.18.0 -v -p main -o schema.go ../../limbo-schema.json
 
 import (
 	"bytes"
@@ -170,13 +170,12 @@ func evaluateTestcase(testcase Testcase) (actualResult, error) {
 		return resultSkipped, fmt.Errorf("unimplemented validationKindClient")
 	case ValidationKindSERVER:
 		var dnsName string
-		if peerName, ok := testcase.ExpectedPeerName.(map[string]interface{}); ok {
-			if peerName["kind"] == "DNS" {
-				dnsName = peerName["value"].(string)
-			} else {
-				// crypto/x509 takes IP subjects in `[addr]` form.
-				dnsName = fmt.Sprintf("[%s]", peerName["value"].(string))
-			}
+		peerName := testcase.ExpectedPeerName
+		if peerName.Kind == "DNS" {
+			dnsName = peerName.Value
+		} else {
+			// crypto/x509 takes IP subjects in `[addr]` form.
+			dnsName = fmt.Sprintf("[%s]", peerName.Value)
 		}
 		roots, intermediates := x509.NewCertPool(), x509.NewCertPool()
 		roots.AppendCertsFromPEM(concatPEMCerts(testcase.TrustedCerts))

--- a/harness/gocryptox509/main.go
+++ b/harness/gocryptox509/main.go
@@ -1,6 +1,6 @@
 package main
 
-//go:generate go run github.com/atombender/go-jsonschema@v0.18.0 -v -p main -o schema.go ../../limbo-schema.json
+//go:generate go run github.com/atombender/go-jsonschema@v0.17.0 -v -p main -o schema.go ../../limbo-schema.json
 
 import (
 	"bytes"
@@ -170,12 +170,13 @@ func evaluateTestcase(testcase Testcase) (actualResult, error) {
 		return resultSkipped, fmt.Errorf("unimplemented validationKindClient")
 	case ValidationKindSERVER:
 		var dnsName string
-		peerName := testcase.ExpectedPeerName
-		if peerName.Kind == "DNS" {
-			dnsName = peerName.Value
-		} else {
-			// crypto/x509 takes IP subjects in `[addr]` form.
-			dnsName = fmt.Sprintf("[%s]", peerName.Value)
+		if peerName, ok := testcase.ExpectedPeerName.(map[string]interface{}); ok {
+			if peerName["kind"] == "DNS" {
+				dnsName = peerName["value"].(string)
+			} else {
+				// crypto/x509 takes IP subjects in `[addr]` form.
+				dnsName = fmt.Sprintf("[%s]", peerName["value"].(string))
+			}
 		}
 		roots, intermediates := x509.NewCertPool(), x509.NewCertPool()
 		roots.AppendCertsFromPEM(concatPEMCerts(testcase.TrustedCerts))

--- a/harness/gocryptox509/schema.go
+++ b/harness/gocryptox509/schema.go
@@ -3,7 +3,6 @@
 package main
 
 import "encoding/json"
-import "errors"
 import "fmt"
 import "reflect"
 import "regexp"
@@ -19,9 +18,9 @@ var enumValues_ExpectedResult = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *ExpectedResult) UnmarshalJSON(value []byte) error {
+func (j *ExpectedResult) UnmarshalJSON(b []byte) error {
 	var v string
-	if err := json.Unmarshal(value, &v); err != nil {
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -69,9 +68,9 @@ var enumValues_Feature = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *Feature) UnmarshalJSON(value []byte) error {
+func (j *Feature) UnmarshalJSON(b []byte) error {
 	var v string
-	if err := json.Unmarshal(value, &v); err != nil {
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -105,9 +104,9 @@ var enumValues_Importance = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *Importance) UnmarshalJSON(value []byte) error {
+func (j *Importance) UnmarshalJSON(b []byte) error {
 	var v string
-	if err := json.Unmarshal(value, &v); err != nil {
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -149,9 +148,9 @@ var enumValues_KeyUsage = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *KeyUsage) UnmarshalJSON(value []byte) error {
+func (j *KeyUsage) UnmarshalJSON(b []byte) error {
 	var v string
-	if err := json.Unmarshal(value, &v); err != nil {
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -189,9 +188,9 @@ var enumValues_KnownEKUs = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *KnownEKUs) UnmarshalJSON(value []byte) error {
+func (j *KnownEKUs) UnmarshalJSON(b []byte) error {
 	var v string
-	if err := json.Unmarshal(value, &v); err != nil {
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -218,9 +217,9 @@ type Limbo struct {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *Limbo) UnmarshalJSON(value []byte) error {
+func (j *Limbo) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
-	if err := json.Unmarshal(value, &raw); err != nil {
+	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
 	if _, ok := raw["testcases"]; raw != nil && !ok {
@@ -231,7 +230,7 @@ func (j *Limbo) UnmarshalJSON(value []byte) error {
 	}
 	type Plain Limbo
 	var plain Plain
-	if err := json.Unmarshal(value, &plain); err != nil {
+	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
 	*j = Limbo(plain)
@@ -251,9 +250,9 @@ var enumValues_PeerKind = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *PeerKind) UnmarshalJSON(value []byte) error {
+func (j *PeerKind) UnmarshalJSON(b []byte) error {
 	var v string
-	if err := json.Unmarshal(value, &v); err != nil {
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -280,9 +279,9 @@ type PeerName struct {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *PeerName) UnmarshalJSON(value []byte) error {
+func (j *PeerName) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
-	if err := json.Unmarshal(value, &raw); err != nil {
+	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
 	if _, ok := raw["kind"]; raw != nil && !ok {
@@ -293,7 +292,7 @@ func (j *PeerName) UnmarshalJSON(value []byte) error {
 	}
 	type Plain PeerName
 	var plain Plain
-	if err := json.Unmarshal(value, &plain); err != nil {
+	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
 	*j = PeerName(plain)
@@ -367,9 +366,9 @@ var enumValues_SignatureAlgorithm = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SignatureAlgorithm) UnmarshalJSON(value []byte) error {
+func (j *SignatureAlgorithm) UnmarshalJSON(b []byte) error {
 	var v string
-	if err := json.Unmarshal(value, &v); err != nil {
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -395,7 +394,7 @@ type Testcase struct {
 	Description string `json:"description" yaml:"description" mapstructure:"description"`
 
 	// For server (i.e. client-side) validation: the expected peer name, if any
-	ExpectedPeerName *TestcaseExpectedPeerName `json:"expected_peer_name,omitempty" yaml:"expected_peer_name,omitempty" mapstructure:"expected_peer_name,omitempty"`
+	ExpectedPeerName interface{} `json:"expected_peer_name,omitempty" yaml:"expected_peer_name,omitempty" mapstructure:"expected_peer_name,omitempty"`
 
 	// For client (i.e. server-side) validation: the expected peer names
 	ExpectedPeerNames []PeerName `json:"expected_peer_names" yaml:"expected_peer_names" mapstructure:"expected_peer_names"`
@@ -448,46 +447,10 @@ type Testcase struct {
 	ValidationTime interface{} `json:"validation_time,omitempty" yaml:"validation_time,omitempty" mapstructure:"validation_time,omitempty"`
 }
 
-// Represents a peer (i.e., end entity) certificate's name (Subject or SAN).
-type TestcaseExpectedPeerName struct {
-	// The kind of peer name
-	Kind PeerKind `json:"kind" yaml:"kind" mapstructure:"kind"`
-
-	// The peer's name
-	Value string `json:"value" yaml:"value" mapstructure:"value"`
-}
-
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *TestcaseExpectedPeerName) UnmarshalJSON(value []byte) error {
+func (j *Testcase) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
-	if err := json.Unmarshal(value, &raw); err != nil {
-		return err
-	}
-	var testcaseExpectedPeerName_0 TestcaseExpectedPeerName_0
-	var testcaseExpectedPeerName_1 TestcaseExpectedPeerName_1
-	var errs []error
-	if err := testcaseExpectedPeerName_0.UnmarshalJSON(value); err != nil {
-		errs = append(errs, err)
-	}
-	if err := testcaseExpectedPeerName_1.UnmarshalJSON(value); err != nil {
-		errs = append(errs, err)
-	}
-	if len(errs) == 2 {
-		return fmt.Errorf("all validators failed: %s", errors.Join(errs...))
-	}
-	type Plain TestcaseExpectedPeerName
-	var plain Plain
-	if err := json.Unmarshal(value, &plain); err != nil {
-		return err
-	}
-	*j = TestcaseExpectedPeerName(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *Testcase) UnmarshalJSON(value []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(value, &raw); err != nil {
+	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
 	if _, ok := raw["description"]; raw != nil && !ok {
@@ -525,7 +488,7 @@ func (j *Testcase) UnmarshalJSON(value []byte) error {
 	}
 	type Plain Testcase
 	var plain Plain
-	if err := json.Unmarshal(value, &plain); err != nil {
+	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
 	if v, ok := raw["conflicts_with"]; !ok || v == nil {
@@ -534,8 +497,8 @@ func (j *Testcase) UnmarshalJSON(value []byte) error {
 	if v, ok := raw["features"]; !ok || v == nil {
 		plain.Features = []Feature{}
 	}
-	if matched, _ := regexp.MatchString(`^([A-Za-z][A-Za-z0-9-.]+::)*([A-Za-z][A-Za-z0-9-.]+)$`, string(plain.Id)); !matched {
-		return fmt.Errorf("field %s pattern match: must match %s", "Id", `^([A-Za-z][A-Za-z0-9-.]+::)*([A-Za-z][A-Za-z0-9-.]+)$`)
+	if matched, _ := regexp.MatchString("^([A-Za-z][A-Za-z0-9-.]+::)*([A-Za-z][A-Za-z0-9-.]+)$", string(plain.Id)); !matched {
+		return fmt.Errorf("field %s pattern match: must match %s", "^([A-Za-z][A-Za-z0-9-.]+::)*([A-Za-z][A-Za-z0-9-.]+)$", "Id")
 	}
 	if v, ok := raw["importance"]; !ok || v == nil {
 		plain.Importance = "undetermined"
@@ -555,9 +518,9 @@ var enumValues_ValidationKind = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *ValidationKind) UnmarshalJSON(value []byte) error {
+func (j *ValidationKind) UnmarshalJSON(b []byte) error {
 	var v string
-	if err := json.Unmarshal(value, &v); err != nil {
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -573,5 +536,3 @@ func (j *ValidationKind) UnmarshalJSON(value []byte) error {
 	*j = ValidationKind(v)
 	return nil
 }
-
-type TestcaseExpectedPeerName_0 = PeerName

--- a/harness/gocryptox509/schema.go
+++ b/harness/gocryptox509/schema.go
@@ -3,6 +3,7 @@
 package main
 
 import "encoding/json"
+import "errors"
 import "fmt"
 import "reflect"
 import "regexp"
@@ -18,9 +19,9 @@ var enumValues_ExpectedResult = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *ExpectedResult) UnmarshalJSON(b []byte) error {
+func (j *ExpectedResult) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -68,9 +69,9 @@ var enumValues_Feature = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *Feature) UnmarshalJSON(b []byte) error {
+func (j *Feature) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -104,9 +105,9 @@ var enumValues_Importance = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *Importance) UnmarshalJSON(b []byte) error {
+func (j *Importance) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -148,9 +149,9 @@ var enumValues_KeyUsage = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *KeyUsage) UnmarshalJSON(b []byte) error {
+func (j *KeyUsage) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -188,9 +189,9 @@ var enumValues_KnownEKUs = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *KnownEKUs) UnmarshalJSON(b []byte) error {
+func (j *KnownEKUs) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -217,9 +218,9 @@ type Limbo struct {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *Limbo) UnmarshalJSON(b []byte) error {
+func (j *Limbo) UnmarshalJSON(value []byte) error {
 	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+	if err := json.Unmarshal(value, &raw); err != nil {
 		return err
 	}
 	if _, ok := raw["testcases"]; raw != nil && !ok {
@@ -230,7 +231,7 @@ func (j *Limbo) UnmarshalJSON(b []byte) error {
 	}
 	type Plain Limbo
 	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
+	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
 	*j = Limbo(plain)
@@ -250,9 +251,9 @@ var enumValues_PeerKind = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *PeerKind) UnmarshalJSON(b []byte) error {
+func (j *PeerKind) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -279,9 +280,9 @@ type PeerName struct {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *PeerName) UnmarshalJSON(b []byte) error {
+func (j *PeerName) UnmarshalJSON(value []byte) error {
 	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+	if err := json.Unmarshal(value, &raw); err != nil {
 		return err
 	}
 	if _, ok := raw["kind"]; raw != nil && !ok {
@@ -292,7 +293,7 @@ func (j *PeerName) UnmarshalJSON(b []byte) error {
 	}
 	type Plain PeerName
 	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
+	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
 	*j = PeerName(plain)
@@ -366,9 +367,9 @@ var enumValues_SignatureAlgorithm = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SignatureAlgorithm) UnmarshalJSON(b []byte) error {
+func (j *SignatureAlgorithm) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -394,7 +395,7 @@ type Testcase struct {
 	Description string `json:"description" yaml:"description" mapstructure:"description"`
 
 	// For server (i.e. client-side) validation: the expected peer name, if any
-	ExpectedPeerName interface{} `json:"expected_peer_name,omitempty" yaml:"expected_peer_name,omitempty" mapstructure:"expected_peer_name,omitempty"`
+	ExpectedPeerName *TestcaseExpectedPeerName `json:"expected_peer_name,omitempty" yaml:"expected_peer_name,omitempty" mapstructure:"expected_peer_name,omitempty"`
 
 	// For client (i.e. server-side) validation: the expected peer names
 	ExpectedPeerNames []PeerName `json:"expected_peer_names" yaml:"expected_peer_names" mapstructure:"expected_peer_names"`
@@ -447,10 +448,46 @@ type Testcase struct {
 	ValidationTime interface{} `json:"validation_time,omitempty" yaml:"validation_time,omitempty" mapstructure:"validation_time,omitempty"`
 }
 
+// Represents a peer (i.e., end entity) certificate's name (Subject or SAN).
+type TestcaseExpectedPeerName struct {
+	// The kind of peer name
+	Kind PeerKind `json:"kind" yaml:"kind" mapstructure:"kind"`
+
+	// The peer's name
+	Value string `json:"value" yaml:"value" mapstructure:"value"`
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *Testcase) UnmarshalJSON(b []byte) error {
+func (j *TestcaseExpectedPeerName) UnmarshalJSON(value []byte) error {
 	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+	if err := json.Unmarshal(value, &raw); err != nil {
+		return err
+	}
+	var testcaseExpectedPeerName_0 TestcaseExpectedPeerName_0
+	var testcaseExpectedPeerName_1 TestcaseExpectedPeerName_1
+	var errs []error
+	if err := testcaseExpectedPeerName_0.UnmarshalJSON(value); err != nil {
+		errs = append(errs, err)
+	}
+	if err := testcaseExpectedPeerName_1.UnmarshalJSON(value); err != nil {
+		errs = append(errs, err)
+	}
+	if len(errs) == 2 {
+		return fmt.Errorf("all validators failed: %s", errors.Join(errs...))
+	}
+	type Plain TestcaseExpectedPeerName
+	var plain Plain
+	if err := json.Unmarshal(value, &plain); err != nil {
+		return err
+	}
+	*j = TestcaseExpectedPeerName(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *Testcase) UnmarshalJSON(value []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(value, &raw); err != nil {
 		return err
 	}
 	if _, ok := raw["description"]; raw != nil && !ok {
@@ -488,7 +525,7 @@ func (j *Testcase) UnmarshalJSON(b []byte) error {
 	}
 	type Plain Testcase
 	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
+	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
 	if v, ok := raw["conflicts_with"]; !ok || v == nil {
@@ -497,8 +534,8 @@ func (j *Testcase) UnmarshalJSON(b []byte) error {
 	if v, ok := raw["features"]; !ok || v == nil {
 		plain.Features = []Feature{}
 	}
-	if matched, _ := regexp.MatchString("^([A-Za-z][A-Za-z0-9-.]+::)*([A-Za-z][A-Za-z0-9-.]+)$", string(plain.Id)); !matched {
-		return fmt.Errorf("field %s pattern match: must match %s", "^([A-Za-z][A-Za-z0-9-.]+::)*([A-Za-z][A-Za-z0-9-.]+)$", "Id")
+	if matched, _ := regexp.MatchString(`^([A-Za-z][A-Za-z0-9-.]+::)*([A-Za-z][A-Za-z0-9-.]+)$`, string(plain.Id)); !matched {
+		return fmt.Errorf("field %s pattern match: must match %s", "Id", `^([A-Za-z][A-Za-z0-9-.]+::)*([A-Za-z][A-Za-z0-9-.]+)$`)
 	}
 	if v, ok := raw["importance"]; !ok || v == nil {
 		plain.Importance = "undetermined"
@@ -518,9 +555,9 @@ var enumValues_ValidationKind = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *ValidationKind) UnmarshalJSON(b []byte) error {
+func (j *ValidationKind) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -536,3 +573,5 @@ func (j *ValidationKind) UnmarshalJSON(b []byte) error {
 	*j = ValidationKind(v)
 	return nil
 }
+
+type TestcaseExpectedPeerName_0 = PeerName

--- a/harness/rust-rustls/Cargo.toml
+++ b/harness/rust-rustls/Cargo.toml
@@ -8,4 +8,5 @@ limbo-harness-support = { path = "../../harness-support/rust" }
 chrono = "0.4.40"
 pem = "3.0.5"
 serde_json = "1.0.139"
-rustls-webpki = { version = "0.103.0", features = ["std"] }
+rustls-webpki = { version = "0.103.0", features = ["std", "ring"] }
+rustls-pki-types = "1.11.0"

--- a/harness/rust-rustls/src/main.rs
+++ b/harness/rust-rustls/src/main.rs
@@ -22,9 +22,9 @@ fn main() {
     serde_json::to_writer_pretty(std::io::stdout(), &result).unwrap();
 }
 
-fn der_from_pem<B: AsRef<[u8]>>(bytes: B) -> webpki::types::CertificateDer<'static> {
+fn der_from_pem<B: AsRef<[u8]>>(bytes: B) -> rustls_pki_types::CertificateDer<'static> {
     let pem = pem::parse(bytes).expect("cert: PEM parse failed");
-    webpki::types::CertificateDer::from(pem.contents()).into_owned()
+    rustls_pki_types::CertificateDer::from(pem.contents()).into_owned()
 }
 
 fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
@@ -72,7 +72,7 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
         return TestcaseResult::fail(tc, "trusted certs: trust anchor extraction failed");
     };
 
-    let validation_time = webpki::types::UnixTime::since_unix_epoch(
+    let validation_time = rustls_pki_types::UnixTime::since_unix_epoch(
         (tc.validation_time.unwrap_or(Utc::now().into()) - DateTime::UNIX_EPOCH)
             .to_std()
             .expect("invalid validation time!"),
@@ -104,13 +104,13 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
     let subject_name = match &tc.expected_peer_name {
         None => return TestcaseResult::skip(tc, "implementation requires peer names"),
         Some(pn) => match pn.kind {
-            PeerKind::Dns => webpki::types::ServerName::DnsName(
-                webpki::types::DnsName::try_from(pn.value.as_str())
+            PeerKind::Dns => rustls_pki_types::ServerName::DnsName(
+                rustls_pki_types::DnsName::try_from(pn.value.as_str())
                     .expect(&format!("invalid expected DNS name: {}", &pn.value)),
             ),
             PeerKind::Ip => {
                 let addr = pn.value.as_str().try_into().unwrap();
-                webpki::types::ServerName::IpAddress(addr)
+                rustls_pki_types::ServerName::IpAddress(addr)
             }
             _ => return TestcaseResult::skip(tc, "implementation requires DNS or IP peer names"),
         },


### PR DESCRIPTION
Fixes the build.

We now depend on `rustls-pki-types` as well.