### PR TITLE
add openssl-3.5 harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ test-go:
 
 .PHONY: test-openssl
 test-openssl:
-	$(MAKE) -C harness/openssl openssl-1.1.1 openssl-3.0 openssl-3.1 openssl-3.2 openssl-3.3 openssl-3.4
+	$(MAKE) -C harness/openssl openssl-1.1.1 openssl-3.0 openssl-3.1 openssl-3.2 openssl-3.3 openssl-3.4 openssl-3.5
 	$(MAKE) run ARGS="harness --output ./results/openssl-1.1.1.json -- docker run --platform linux/amd64 --rm -i x509-limbo-openssl-1.1.1"
 	$(MAKE) run ARGS="harness --output ./results/openssl-3.0.json -- docker run --platform linux/amd64 --rm -i x509-limbo-openssl-3.0"
 	$(MAKE) run ARGS="harness --output ./results/openssl-3.1.json -- docker run --platform linux/amd64 --rm -i x509-limbo-openssl-3.1"

--- a/Makefile
+++ b/Makefile
@@ -80,10 +80,9 @@ test-go:
 
 .PHONY: test-openssl
 test-openssl:
-	$(MAKE) -C harness/openssl openssl-1.1.1 openssl-3.0 openssl-3.1 openssl-3.2 openssl-3.3 openssl-3.4 openssl-3.5
+	$(MAKE) -C harness/openssl openssl-1.1.1 openssl-3.0 openssl-3.2 openssl-3.3 openssl-3.4 openssl-3.5
 	$(MAKE) run ARGS="harness --output ./results/openssl-1.1.1.json -- docker run --platform linux/amd64 --rm -i x509-limbo-openssl-1.1.1"
 	$(MAKE) run ARGS="harness --output ./results/openssl-3.0.json -- docker run --platform linux/amd64 --rm -i x509-limbo-openssl-3.0"
-	$(MAKE) run ARGS="harness --output ./results/openssl-3.1.json -- docker run --platform linux/amd64 --rm -i x509-limbo-openssl-3.1"
 	$(MAKE) run ARGS="harness --output ./results/openssl-3.2.json -- docker run --platform linux/amd64 --rm -i x509-limbo-openssl-3.2"
 	$(MAKE) run ARGS="harness --output ./results/openssl-3.3.json -- docker run --platform linux/amd64 --rm -i x509-limbo-openssl-3.3"
 	$(MAKE) run ARGS="harness --output ./results/openssl-3.4.json -- docker run --platform linux/amd64 --rm -i x509-limbo-openssl-3.4"

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ test-openssl:
 	$(MAKE) run ARGS="harness --output ./results/openssl-3.2.json -- docker run --platform linux/amd64 --rm -i x509-limbo-openssl-3.2"
 	$(MAKE) run ARGS="harness --output ./results/openssl-3.3.json -- docker run --platform linux/amd64 --rm -i x509-limbo-openssl-3.3"
 	$(MAKE) run ARGS="harness --output ./results/openssl-3.4.json -- docker run --platform linux/amd64 --rm -i x509-limbo-openssl-3.4"
+	$(MAKE) run ARGS="harness --output ./results/openssl-3.5.json -- docker run --platform linux/amd64 --rm -i x509-limbo-openssl-3.5"
 
 .PHONY: test-rust-webpki
 test-rust-webpki:

--- a/harness/openssl/README.md
+++ b/harness/openssl/README.md
@@ -3,7 +3,7 @@
 This directory contains a basic test harness for running the x509-testsuite
 against OpenSSL.
 
-OpenSSL 1.1, 3.0, and 3.1 should all work.
+OpenSSL 1.1, 3.0, and forwards should all work.
 
 ## Building
 

--- a/harness/openssl/openssl-3.1.dockerfile
+++ b/harness/openssl/openssl-3.1.dockerfile
@@ -1,9 +1,0 @@
-FROM ghcr.io/woodruffw/openssl-dockerfiles/openssl-3.1:latest
-
-WORKDIR /tmp/harness
-
-COPY ./ .
-
-RUN make
-
-ENTRYPOINT ["./main"]

--- a/harness/openssl/openssl-3.5.dockerfile
+++ b/harness/openssl/openssl-3.5.dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/woodruffw/openssl-dockerfiles/openssl-3.5:latest
+
+WORKDIR /tmp/harness
+
+COPY ./ .
+
+RUN make
+
+ENTRYPOINT ["./main"]


### PR DESCRIPTION
OpenSSL releases a new version, and I am duty bound to follow with a harness.

Also removes the 3.1 harness, since 3.1 is now EOL.