### PR TITLE
perf: remove PEM bundles from site render

### DIFF
--- a/limbo/_assets/templates/testcase.md
+++ b/limbo/_assets/templates/testcase.md
@@ -3,8 +3,8 @@
 
 {{ description }}
 
-| Expected result | Validation kind | Validation time | Features       | Importance       | Conflicts       | Download   |
-| --------------- | --------------- | --------------- | -------------- | ---------------- | --------------- | ---------- |
-| {{ exp_result }}| {{ val_kind }}  | {{ val_time }}  | {{ features }} | {{ importance }} | {{ conflicts }} | {{ pems }} |   |
+| Expected result | Validation kind | Validation time | Features       | Importance       | Conflicts       |
+| --------------- | --------------- | --------------- | -------------- | ---------------- | --------------- |
+| {{ exp_result }}| {{ val_kind }}  | {{ val_time }}  | {{ features }} | {{ importance }} | {{ conflicts }} |
 
 {{ harness_results }}


### PR DESCRIPTION
Also optimize some reads slightly. On my local machine, this shaves a few seconds off the site build (but it remains ridiculously slow for unclear reasons; maybe something quadradic in mkdocs itself).