### PR TITLE
Add CRL verification support to rustls-webpki, fixup CRL test case

### DIFF
--- a/harness/rust-rustls/src/main.rs
+++ b/harness/rust-rustls/src/main.rs
@@ -70,14 +70,14 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
 
     let Ok(trust_anchors) = trust_anchor_ders
         .iter()
-        .map(|ta| webpki::anchor_from_trusted_cert(ta.into()))
+        .map(|ta| webpki::anchor_from_trusted_cert(ta))
         .collect::<Result<Vec<_>, _>>()
     else {
         return TestcaseResult::fail(tc, "trusted certs: trust anchor extraction failed");
     };
 
     let validation_time = rustls_pki_types::UnixTime::since_unix_epoch(
-        (tc.validation_time.unwrap_or(Utc::now().into()) - DateTime::UNIX_EPOCH)
+        (tc.validation_time.unwrap_or(Utc::now()) - DateTime::UNIX_EPOCH)
             .to_std()
             .expect("invalid validation time!"),
     );

--- a/harness/rust-rustls/src/main.rs
+++ b/harness/rust-rustls/src/main.rs
@@ -27,16 +27,19 @@ fn cert_der_from_pem<B: AsRef<[u8]>>(bytes: B) -> rustls_pki_types::CertificateD
     rustls_pki_types::CertificateDer::from(pem.contents()).into_owned()
 }
 
+fn crl_der_from_pem<B: AsRef<[u8]>>(
+    bytes: B,
+) -> rustls_pki_types::CertificateRevocationListDer<'static> {
+    let pem = pem::parse(bytes).expect("crl: PEM parse failed");
+    rustls_pki_types::CertificateRevocationListDer::from(pem.into_contents())
+}
+
 fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
     if tc.features.contains(&Feature::MaxChainDepth) {
         return TestcaseResult::skip(
             tc,
             "max-chain-depth testcases are not supported by this API",
         );
-    }
-
-    if tc.features.contains(&Feature::HasCrl) {
-        return TestcaseResult::skip(tc, "CRLs are not supported by this API");
     }
 
     if !matches!(tc.validation_kind, ValidationKind::Server) {
@@ -93,13 +96,34 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
         ring::RSA_PSS_2048_8192_SHA512_LEGACY_KEY,
     ];
 
+    let crls = tc
+        .crls
+        .iter()
+        .map(|pem| {
+            webpki::OwnedCertRevocationList::from_der(crl_der_from_pem(pem).as_ref())
+                .unwrap_or_else(|e| panic!("crl: tc {} DER parse failed: {e}", tc.id.to_string()))
+                .into()
+        })
+        .collect::<Vec<_>>();
+    let crls = crls.iter().collect::<Vec<_>>();
+
+    let revocation_options = if !crls.is_empty() {
+        let opts = webpki::RevocationOptionsBuilder::new(crls.as_slice()).unwrap();
+        opts.with_depth(webpki::RevocationCheckDepth::Chain);
+        opts.with_status_policy(webpki::UnknownStatusPolicy::Deny);
+        opts.with_expiration_policy(webpki::ExpirationPolicy::Enforce);
+        Some(opts.build())
+    } else {
+        None
+    };
+
     if let Err(e) = leaf.verify_for_usage(
         sig_algs,
         &trust_anchors,
         &intermediates[..],
         validation_time,
         webpki::KeyUsage::server_auth(),
-        None,
+        revocation_options,
         None,
     ) {
         return TestcaseResult::fail(tc, &e.to_string());

--- a/harness/rust-rustls/src/main.rs
+++ b/harness/rust-rustls/src/main.rs
@@ -70,7 +70,7 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
 
     let Ok(trust_anchors) = trust_anchor_ders
         .iter()
-        .map(|ta| webpki::anchor_from_trusted_cert(ta))
+        .map(webpki::anchor_from_trusted_cert)
         .collect::<Result<Vec<_>, _>>()
     else {
         return TestcaseResult::fail(tc, "trusted certs: trust anchor extraction failed");

--- a/harness/rust-rustls/src/main.rs
+++ b/harness/rust-rustls/src/main.rs
@@ -36,10 +36,7 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
     }
 
     if tc.features.contains(&Feature::HasCrl) {
-        return TestcaseResult::skip(
-            tc,
-            "CRLs are not supported by this API",
-        );
+        return TestcaseResult::skip(tc, "CRLs are not supported by this API");
     }
 
     if !matches!(tc.validation_kind, ValidationKind::Server) {

--- a/harness/rust-rustls/src/main.rs
+++ b/harness/rust-rustls/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
     serde_json::to_writer_pretty(std::io::stdout(), &result).unwrap();
 }
 
-fn der_from_pem<B: AsRef<[u8]>>(bytes: B) -> rustls_pki_types::CertificateDer<'static> {
+fn cert_der_from_pem<B: AsRef<[u8]>>(bytes: B) -> rustls_pki_types::CertificateDer<'static> {
     let pem = pem::parse(bytes).expect("cert: PEM parse failed");
     rustls_pki_types::CertificateDer::from(pem.contents()).into_owned()
 }
@@ -51,7 +51,7 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
         return TestcaseResult::skip(tc, "key_usage not supported yet");
     }
 
-    let leaf_der = der_from_pem(&tc.peer_certificate);
+    let leaf_der = cert_der_from_pem(&tc.peer_certificate);
     let Ok(leaf) = webpki::EndEntityCert::try_from(&leaf_der) else {
         return TestcaseResult::fail(tc, "leaf cert: X.509 parse failed");
     };
@@ -59,13 +59,13 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
     let intermediates = tc
         .untrusted_intermediates
         .iter()
-        .map(|ic| der_from_pem(ic))
+        .map(|ic| cert_der_from_pem(ic))
         .collect::<Vec<_>>();
 
     let trust_anchor_ders = tc
         .trusted_certs
         .iter()
-        .map(|ta| der_from_pem(ta))
+        .map(|ta| cert_der_from_pem(ta))
         .collect::<Vec<_>>();
 
     let Ok(trust_anchors) = trust_anchor_ders

--- a/harness/rust-rustls/src/main.rs
+++ b/harness/rust-rustls/src/main.rs
@@ -120,7 +120,7 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
         },
     };
 
-    if let Err(_) = leaf.verify_is_valid_for_subject_name(&subject_name) {
+    if leaf.verify_is_valid_for_subject_name(&subject_name).is_err() {
         TestcaseResult::fail(tc, "subject name validation failed")
     } else {
         TestcaseResult::success(tc)


### PR DESCRIPTION
:wave: Hi folks,

One of the features that distinguishes the Rustls fork of `webpki` from its predecessor is support for revocation checking with CRLs. This branch updates the x509-limbo harness to take advantage of that.

However, our CRL parser tries to be fairly strict. In particular, since [RFC 5280 §5.2](https://www.rfc-editor.org/rfc/rfc5280#section-5.2) requires the CRL number and authority key identifier extensions be present in all CRLs we error if given CRL DER without an  extensions section. Unfortunately this was the case for the one CRL test-case in `limbo.json` so I had to rework the testcase & regenerate the test CRL in order for our harness to support the test.

On a separate note, we use `pyca/cryptography` to generate [a number of CRL test cases](https://github.com/rustls/webpki/blob/main/tests/crls/make_testcrls.py). Would you be interested in seeing some of those ported into limbo to extend the CRL coverage? Are there any you think are best left out?