### PR TITLE
feat: add CRL builder API

### DIFF
--- a/limbo/testcases/crl.py
+++ b/limbo/testcases/crl.py
@@ -76,10 +76,7 @@ def missing_crlnumber(builder: Builder) -> None:
     """
     Tests handling of a CRL that's missing the `CRLNumber` extension.
 
-    Per RFC 5280 5.2.3 this extension MUST be included in a CRL. Therefore,
-    a CRL that does not include this extension is considered invalid,
-    and therefore certificate validation should pass, even if the CRL
-    revokes the leaf being verified.
+    Per RFC 5280 5.2.3 this extension MUST be included in a CRL.
     """
 
     root = builder.root_ca(
@@ -116,8 +113,11 @@ def missing_crlnumber(builder: Builder) -> None:
     crl = builder.crl(
         signer=root,
         revoked=[
+            # Revoke a random certificate here, not the leaf,
+            # to ensure that we fail because the CRL is invalid,
+            # not because the leaf is revoked.
             x509.RevokedCertificateBuilder()
-            .serial_number(leaf.cert.serial_number)
+            .serial_number(x509.random_serial_number())
             .revocation_date(leaf.cert.not_valid_before_utc + timedelta(seconds=1))
             .build()
         ],
@@ -135,7 +135,7 @@ def missing_crlnumber(builder: Builder) -> None:
         )
         .crls(crl)
         .validation_time(leaf.cert.not_valid_before_utc + timedelta(seconds=2))
-        .succeeds()
+        .fails()
     )
 
 
@@ -145,9 +145,7 @@ def crlnumber_critical(builder: Builder) -> None:
     Tests handling of a CRL that has a critical `CRLNumber` extension.
 
     Per RFC 5280 5.2.3, the `CRLNumber` extension is mandatory but MUST
-    be marked as non-critical. Therefore, a CRL that has a critical `CRLNumber`
-    extension is considered invalid, and therefore certificate validation
-    should pass, even if the CRL revokes the leaf being verified.
+    be marked as non-critical.
     """
 
     root = builder.root_ca(
@@ -184,8 +182,11 @@ def crlnumber_critical(builder: Builder) -> None:
     crl = builder.crl(
         signer=root,
         revoked=[
+            # Revoke a random certificate here, not the leaf,
+            # to ensure that we fail because the CRL is invalid,
+            # not because the leaf is revoked.
             x509.RevokedCertificateBuilder()
-            .serial_number(leaf.cert.serial_number)
+            .serial_number(x509.random_serial_number())
             .revocation_date(leaf.cert.not_valid_before_utc + timedelta(seconds=1))
             .build()
         ],
@@ -203,5 +204,5 @@ def crlnumber_critical(builder: Builder) -> None:
         )
         .crls(crl)
         .validation_time(leaf.cert.not_valid_before_utc + timedelta(seconds=2))
-        .succeeds()
+        .fails()
     )

--- a/limbo/testcases/crl.py
+++ b/limbo/testcases/crl.py
@@ -72,7 +72,7 @@ def revoked_certificate_with_crl(builder: Builder) -> None:
 
 
 @testcase
-def missing_crlnumber(builder: Builder) -> None:
+def crlnumber_missing(builder: Builder) -> None:
     """
     Tests handling of a CRL that's missing the `CRLNumber` extension.
 


### PR DESCRIPTION
~~WIP -- I'm going to add some crit/non-crit extension CRL testcases now that I've added a builder API here.~~

This adds a "builder" style API that should make CRL testcase construction more fluent.

It also adds two new testcases that exercise the API.