### PR TITLE
limbo/testcases: adjust builder peer name defaults

### DIFF
--- a/limbo/testcases/_core.py
+++ b/limbo/testcases/_core.py
@@ -448,10 +448,12 @@ class Builder:
 
     def client_validation(self) -> Self:
         self._validation_kind = "CLIENT"
+        self._expected_peer_name = None
         return self
 
     def server_validation(self) -> Self:
         self._validation_kind = "SERVER"
+        self._expected_peer_names = []
         return self
 
     def trusted_certs(self, *certs: Certificate) -> Self:


### PR DESCRIPTION
When using `client_validation()`, clear `_expected_peer_name`. When using `server_validation()`, clear `_expected_peer_names`.

By default the `Builder` adds an `expected_peer_name` SAN and this is sensible since the majority of test cases are `validation_kind == "SERVER"`. However, for `validation_kind == "CLIENT"` this field shouldn't be set and `expected_peer_names` (plural) used instead.

This change fixes four name constraint test cases that had a DNS name SAN for example.com in the `expected_peer_name` field despite being `validation_kind == "CLIENT"` test cases:

  rfc5280::nc::invalid-email-address
  rfc5280::nc::nc-permits-invalid-email-san
  rfc5280::nc::nc-permits-email-exact
  rfc5280::nc::nc-permits-email-domain

See #524.