### PR TITLE
Add CABF Subscriber EKU test cases

### DIFF
--- a/limbo/testcases/webpki/eku.py
+++ b/limbo/testcases/webpki/eku.py
@@ -129,3 +129,261 @@ def root_has_eku(builder: Builder) -> None:
         .peer_certificate(leaf)
         .fails()
     )
+
+
+@testcase
+def ee_clientauth_only(builder: Builder) -> None:
+    """
+    Produces the following **invalid** chain:
+
+    ```
+    root -> EE
+    ```
+
+    This chain is correctly constructed, but the EE cert contains an
+    Extended Key Usage extension that only contains id-kp-clientAuth,
+    missing the required id-kp-serverAuth OID.
+    Per CABF BR 7.1.2.7.10, subscriber certificates MUST include
+    id-kp-serverAuth (1.3.6.1.5.5.7.3.1).
+    """
+
+    root = builder.root_ca()
+    leaf = builder.leaf_cert(
+        root,
+        eku=ext(
+            x509.ExtendedKeyUsage([x509.OID_CLIENT_AUTH]),
+            critical=False,
+        ),
+    )
+
+    builder = builder.server_validation().features([Feature.pedantic_webpki_eku])
+    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
+        PeerName(kind="DNS", value="example.com")
+    ).extended_key_usage([KnownEKUs.server_auth]).fails()
+
+
+@testcase
+def ee_precertificate_only(builder: Builder) -> None:
+    """
+    Produces the following **invalid** chain:
+
+    ```
+    root -> EE
+    ```
+
+    This chain is correctly constructed, but the EE cert contains an
+    Extended Key Usage extension that only contains the Precertificate
+    Signing Certificate OID (1.3.6.1.4.1.11129.2.4.4).
+    Per CABF BR 7.1.2.7.10, this OID MUST NOT appear in subscriber
+    certificates. Per RFC 6962 Section 3.1, this OID is reserved for
+    special-purpose CA certificates used in Certificate Transparency.
+    """
+
+    # Create the precertificate OID
+    precertificate_oid = x509.ObjectIdentifier("1.3.6.1.4.1.11129.2.4.4")
+
+    root = builder.root_ca()
+    leaf = builder.leaf_cert(
+        root,
+        eku=ext(
+            x509.ExtendedKeyUsage([precertificate_oid]),
+            critical=False,
+        ),
+    )
+
+    builder = builder.server_validation().features([Feature.pedantic_webpki_eku])
+    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
+        PeerName(kind="DNS", value="example.com")
+    ).extended_key_usage([KnownEKUs.server_auth]).fails()
+
+
+@testcase
+def ee_precertificate_with_serverauth(builder: Builder) -> None:
+    """
+    Produces the following **invalid** chain:
+
+    ```
+    root -> EE
+    ```
+
+    This chain is correctly constructed, but the EE cert contains an
+    Extended Key Usage extension that includes both id-kp-serverAuth and
+    the Precertificate Signing Certificate OID (1.3.6.1.4.1.11129.2.4.4).
+    Per CABF BR 7.1.2.7.10, the Precertificate Signing Certificate OID
+    MUST NOT appear in subscriber certificates, even when id-kp-serverAuth
+    is present. Per RFC 6962 Section 3.1, this OID is reserved for
+    special-purpose CA certificates used in Certificate Transparency.
+    """
+
+    # Create the precertificate OID
+    precertificate_oid = x509.ObjectIdentifier("1.3.6.1.4.1.11129.2.4.4")
+
+    root = builder.root_ca()
+    leaf = builder.leaf_cert(
+        root,
+        eku=ext(
+            x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH, precertificate_oid]),
+            critical=False,
+        ),
+    )
+
+    builder = builder.server_validation().features([Feature.pedantic_webpki_eku])
+    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
+        PeerName(kind="DNS", value="example.com")
+    ).extended_key_usage([KnownEKUs.server_auth]).fails()
+
+
+@testcase
+def ee_serverauth_with_additional(builder: Builder) -> None:
+    """
+    Produces the following **valid** chain:
+
+    ```
+    root -> EE
+    ```
+
+    This chain is correctly constructed. The EE cert contains an
+    Extended Key Usage extension that includes id-kp-serverAuth along with
+    id-kp-clientAuth. Per CABF BR 7.1.2.7.10, id-kp-serverAuth MUST be
+    present and id-kp-clientAuth MAY be present, so this combination is valid.
+    """
+
+    root = builder.root_ca()
+    leaf = builder.leaf_cert(
+        root,
+        eku=ext(
+            x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH, x509.OID_CLIENT_AUTH]),
+            critical=False,
+        ),
+    )
+
+    builder = builder.server_validation().features([Feature.pedantic_webpki_eku])
+    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
+        PeerName(kind="DNS", value="example.com")
+    ).extended_key_usage([KnownEKUs.server_auth]).succeeds()
+
+
+@testcase
+def ee_codesigning_with_serverauth(builder: Builder) -> None:
+    """
+    Produces the following **invalid** chain:
+
+    ```
+    root -> EE
+    ```
+
+    This chain is correctly constructed, but the EE cert contains an
+    Extended Key Usage extension that includes both id-kp-serverAuth and
+    id-kp-codeSigning (1.3.6.1.5.5.7.3.3).
+    Per CABF BR 7.1.2.7.10, id-kp-codeSigning MUST NOT appear in
+    subscriber certificates for TLS.
+    """
+
+    root = builder.root_ca()
+    leaf = builder.leaf_cert(
+        root,
+        eku=ext(
+            x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH, x509.ExtendedKeyUsageOID.CODE_SIGNING]),
+            critical=False,
+        ),
+    )
+
+    builder = builder.server_validation().features([Feature.pedantic_webpki_eku])
+    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
+        PeerName(kind="DNS", value="example.com")
+    ).extended_key_usage([KnownEKUs.server_auth]).fails()
+
+
+@testcase
+def ee_emailprotection_with_serverauth(builder: Builder) -> None:
+    """
+    Produces the following **invalid** chain:
+
+    ```
+    root -> EE
+    ```
+
+    This chain is correctly constructed, but the EE cert contains an
+    Extended Key Usage extension that includes both id-kp-serverAuth and
+    id-kp-emailProtection (1.3.6.1.5.5.7.3.4).
+    Per CABF BR 7.1.2.7.10, id-kp-emailProtection MUST NOT appear in
+    subscriber certificates for TLS.
+    """
+
+    root = builder.root_ca()
+    leaf = builder.leaf_cert(
+        root,
+        eku=ext(
+            x509.ExtendedKeyUsage(
+                [x509.OID_SERVER_AUTH, x509.ExtendedKeyUsageOID.EMAIL_PROTECTION]
+            ),
+            critical=False,
+        ),
+    )
+
+    builder = builder.server_validation().features([Feature.pedantic_webpki_eku])
+    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
+        PeerName(kind="DNS", value="example.com")
+    ).extended_key_usage([KnownEKUs.server_auth]).fails()
+
+
+@testcase
+def ee_timestamping_with_serverauth(builder: Builder) -> None:
+    """
+    Produces the following **invalid** chain:
+
+    ```
+    root -> EE
+    ```
+
+    This chain is correctly constructed, but the EE cert contains an
+    Extended Key Usage extension that includes both id-kp-serverAuth and
+    id-kp-timeStamping (1.3.6.1.5.5.7.3.8).
+    Per CABF BR 7.1.2.7.10, id-kp-timeStamping MUST NOT appear in
+    subscriber certificates for TLS.
+    """
+
+    root = builder.root_ca()
+    leaf = builder.leaf_cert(
+        root,
+        eku=ext(
+            x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH, x509.ExtendedKeyUsageOID.TIME_STAMPING]),
+            critical=False,
+        ),
+    )
+
+    builder = builder.server_validation().features([Feature.pedantic_webpki_eku])
+    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
+        PeerName(kind="DNS", value="example.com")
+    ).extended_key_usage([KnownEKUs.server_auth]).fails()
+
+
+@testcase
+def ee_ocspsigning_with_serverauth(builder: Builder) -> None:
+    """
+    Produces the following **invalid** chain:
+
+    ```
+    root -> EE
+    ```
+
+    This chain is correctly constructed, but the EE cert contains an
+    Extended Key Usage extension that includes both id-kp-serverAuth and
+    id-kp-OCSPSigning (1.3.6.1.5.5.7.3.9).
+    Per CABF BR 7.1.2.7.10, id-kp-OCSPSigning MUST NOT appear in
+    subscriber certificates for TLS.
+    """
+
+    root = builder.root_ca()
+    leaf = builder.leaf_cert(
+        root,
+        eku=ext(
+            x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH, x509.ExtendedKeyUsageOID.OCSP_SIGNING]),
+            critical=False,
+        ),
+    )
+
+    builder = builder.server_validation().features([Feature.pedantic_webpki_eku])
+    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
+        PeerName(kind="DNS", value="example.com")
+    ).extended_key_usage([KnownEKUs.server_auth]).fails()


### PR DESCRIPTION
This PR adds test cases for CABF Baseline Requirements 7.1.2.7.10 regarding subscriber Extended Key Usage (EKU) validation.

There are 8 new test cases:
- `ee_clientauth_only`: Tests rejection when only `clientAuth` is present (`serverAuth` is missing)
- `ee_precertificate_only`: Tests rejection when only precertificate OID is present (`serverAuth` is missing)
- `ee_precertificate_with_serverauth`: Tests rejection of `serverAuth` and precertificate OID
- `ee_serverauth_with_additional`: Tests acceptance when `serverAuth` and `clientAuth` are present
- `ee_codesigning_with_serverauth`: Tests rejection of  `serverAuth` and `codeSigning`
- `ee_emailprotection_with_serverauth`: Tests rejection of  `serverAuth` and `emailProtection`
- `ee_timestamping_with_serverauth`:  Tests rejection of  `serverAuth` and `timeStamping`
- `ee_ocspsigning_with_serverauth`:  Tests rejection of  `serverAuth` and `OCSPSigning`

🤖 Generated with [Claude Code](https://claude.com/claude-code)