### PR TITLE
harness/rust-rustls: skip invalid roots

### DIFF
--- a/harness/rust-rustls/src/main.rs
+++ b/harness/rust-rustls/src/main.rs
@@ -71,13 +71,19 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
         .map(|ta| cert_der_from_pem(ta))
         .collect::<Vec<_>>();
 
-    let Ok(trust_anchors) = trust_anchor_ders
+    let trust_anchors = trust_anchor_ders
         .iter()
-        .map(webpki::anchor_from_trusted_cert)
-        .collect::<Result<Vec<_>, _>>()
-    else {
-        return TestcaseResult::fail(tc, "trusted certs: trust anchor extraction failed");
-    };
+        .filter_map(|der| {
+            webpki::anchor_from_trusted_cert(der)
+                .inspect_err(|e| {
+                    eprintln!(
+                        "warning: {}: skipping invalid trust anchor: {e}",
+                        tc.id.to_string()
+                    );
+                })
+                .ok()
+        })
+        .collect::<Vec<_>>();
 
     let validation_time = rustls_pki_types::UnixTime::since_unix_epoch(
         (tc.validation_time.unwrap_or(Utc::now()) - DateTime::UNIX_EPOCH)


### PR DESCRIPTION
Follow-up to https://github.com/C2SP/x509-limbo/pull/585 that I (hope/expect) will fix the rustls-webpki result to match expected.

If a trust anchor from the test data is invalid/unsupported, skip it and run the rest of the test. For cases where the invalid root isn't necessary we should expect path building to succeed. For other cases, we'll fail later on when we can't build a path because the root is missing.
