### PR TITLE
Add aws-lc harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,11 @@ test-boringssl:
 	$(MAKE) -C harness/openssl boringssl
 	$(MAKE) run ARGS="harness --output ./results/boringssl-legacy.json -- docker run --rm -i x509-limbo-boringssl"
 
+.PHONY: test-aws-lc
+test-aws-lc:
+	$(MAKE) -C harness/openssl aws-lc
+	$(MAKE) run ARGS="harness --output ./results/aws-lc.json -- docker run --rm -i x509-limbo-aws-lc"
+
 .PHONY: test-rust-webpki
 test-rust-webpki:
 	@cargo build --bin rust-webpki-harness
@@ -125,7 +130,7 @@ test-gnutls:
 	$(MAKE) run ARGS="harness --output ./results/gnutls.json -- ./$(VENV_BIN)/python ./harness/gnutls/test-gnutls"
 
 .PHONY: test
-test: test-go test-openssl test-libressl test-boringssl test-rust-webpki test-rustls-webpki test-pyca-cryptography test-certvalidator test-gnutls
+test: test-go test-openssl test-libressl test-boringssl test-aws-lc test-rust-webpki test-rustls-webpki test-pyca-cryptography test-certvalidator test-gnutls
 
 .PHONY: site
 site: $(NEEDS_VENV)

--- a/harness/openssl/Makefile
+++ b/harness/openssl/Makefile
@@ -21,3 +21,6 @@ libressl-%: libressl-%.dockerfile
 
 boringssl: boringssl.dockerfile
 	docker build -f $< . -t x509-limbo-boringssl
+
+aws-lc: aws-lc.dockerfile
+	docker build -f $< . -t x509-limbo-aws-lc

--- a/harness/openssl/aws-lc.dockerfile
+++ b/harness/openssl/aws-lc.dockerfile
@@ -1,0 +1,47 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+# Inspired by:
+# https://github.com/woodruffw/openssl-dockerfiles/blob/1587dafa01254dd377c69a75a2d17d320acc2be1/boringssl.dockerfile
+# https://github.com/aws/aws-lc/blob/9ce727c8b66d39c4df44149eda71c54d033cb299/.github/docker_images/alpine-linux/Dockerfile
+
+FROM alpine
+
+WORKDIR /tmp
+
+RUN apk add --no-cache \
+    cmake \
+    g++ \
+    gcc \
+    libc-dev \
+    ninja \
+    perl \
+    pkgconf \
+    git \
+    go \
+    make \
+    linux-headers
+
+RUN git clone --depth 1 https://github.com/aws/aws-lc.git
+
+WORKDIR /tmp/aws-lc
+
+RUN cmake -G Ninja -B build \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DCMAKE_INSTALL_PREFIX=/build/aws-lc \
+        -DBUILD_TESTING=OFF && \
+    ninja -C build install
+
+WORKDIR /build/aws-lc
+
+RUN rm -rf /tmp/aws-lc
+
+ENV PKG_CONFIG_PATH=/build/aws-lc/lib/pkgconfig/
+
+WORKDIR /tmp/harness
+
+COPY ./ .
+
+RUN make
+
+ENTRYPOINT ["./main"]

--- a/harness/openssl/main.cpp
+++ b/harness/openssl/main.cpp
@@ -24,6 +24,8 @@ static constexpr std::string_view harness_version()
   constexpr auto pos = text.rfind(' ');
   static_assert(pos != std::string_view::npos);
   return text.substr(pos + 1);
+#elif defined(AWSLC_API_VERSION)
+  return AWSLC_VERSION_NUMBER_STRING;
 #elif defined(OPENSSL_IS_BORINGSSL)
   return STRINGIFY(BORINGSSL_API_VERSION);
 #elif defined(OPENSSL_VERSION_STR)
@@ -39,6 +41,8 @@ static constexpr std::string_view harness_version()
 
 #if defined(LIBRESSL_VERSION_NUMBER)
 #define HARNESS_NAME "libressl-"
+#elif defined(AWSLC_API_VERSION)
+#define HARNESS_NAME "aws-lc-"
 #elif defined(OPENSSL_IS_BORINGSSL)
 // NOTE: We add the "legacy" suffix to distinguish from BoringSSL's libpki
 // implementation of path validation, which isn't tested here.
@@ -110,8 +114,8 @@ STACK_OF_X509_ptr x509_stack(const json &certs)
     barf("unexpected type: expected an array of certs");
   }
 
-#if defined(LIBRESSL_VERSION_NUMBER) || defined(OPENSSL_IS_BORINGSSL)
-  // LibreSSL/BoringSSL doesn't have `sk_X509_new_reserve`.
+#if defined(LIBRESSL_VERSION_NUMBER) || defined(OPENSSL_IS_BORINGSSL) || defined(AWSLC_API_VERSION)
+  // LibreSSL/BoringSSL/AWS-LC doesn't have `sk_X509_new_reserve`.
   auto *stack = sk_X509_new_null();
 #else
   auto *stack = sk_X509_new_reserve(nullptr, certs.size());
@@ -226,7 +230,7 @@ json evaluate_testcase(const json &testcase)
 
   auto param = X509_STORE_CTX_get0_param(ctx.get());
 
-#if !defined(OPENSSL_IS_BORINGSSL)
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(AWSLC_API_VERSION)
   // The default authentication level is 1, which corresponds to 80 bits
   // of security. Level 2 corresponds to 112 bits and includes RSA 2048,
   // which brings the validation logic very slightly closer to the Web PKI.


### PR DESCRIPTION
Ref #168

This adds an aws-lc harness using the shared openssl harness. aws-lc is a fork of BoringSSL but does not define `OPENSSL_IS_BORINGSSL`, so the harness detects it via `AWSLC_API_VERSION` and adds the necessary compatibility guards (`sk_X509_new_reserve`, `X509_VERIFY_PARAM_set_auth_level`). The Dockerfile builds aws-lc from source on Alpine, following the same pattern as the BoringSSL harness.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.