### PR TITLE
harness-support: embed limbo.json

### DIFF
--- a/harness-support/rust/src/lib.rs
+++ b/harness-support/rust/src/lib.rs
@@ -5,3 +5,5 @@ pub mod models;
 pub fn load_limbo() -> Limbo {
     serde_json::from_reader(std::io::stdin()).unwrap()
 }
+
+pub const LIMBO_JSON: &[u8] = include_bytes!("../../../limbo.json");


### PR DESCRIPTION
For downstream projects that take a Cargo git dependency on the harness-support crate to integrate x509-limbo it's helpful to also be able to consume the limbo.json data file through the same crate. This avoids needing to vendor it separately and keep it updated through some other mechanism.