### PR TITLE
Additional PSL wildcard SAN testcases

### DIFF
--- a/limbo/testcases/webpki/san.py
+++ b/limbo/testcases/webpki/san.py
@@ -179,6 +179,59 @@ def public_suffix_wildcard_san(builder: Builder) -> None:
 
 
 @testcase
+def public_suffix_multi_label_wildcard_san(builder: Builder) -> None:
+    """
+    Produces a chain with an EE cert.
+
+    This EE cert contains a Subject Alternative Name with the dNSName `*.co.uk`.
+    Like the `*.com` case, conformant CAs should not issue such a certificate,
+    per CABF, and clients should reject it.
+
+    Unlike the `*.com` case, the wildcard here is followed by two labels.
+    Implementations that approximate the "public suffix" rule with a simple
+    "wildcard must be followed by at least two labels" heuristic will
+    incorrectly accept this certificate; rejecting it requires a real PSL
+    lookup (or an equivalent enumeration of multi-label public suffixes).
+    """
+    root = builder.root_ca()
+    leaf = builder.leaf_cert(
+        root,
+        san=ext(x509.SubjectAlternativeName([x509.DNSName("*.co.uk")]), critical=False),
+    )
+
+    builder = builder.server_validation().features([Feature.pedantic_public_suffix_wildcard])
+    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
+        PeerName(kind="DNS", value="example.co.uk")
+    ).fails()
+
+
+@testcase
+def public_suffix_private_namespace_wildcard_san(builder: Builder) -> None:
+    """
+    Produces a chain with an EE cert.
+
+    This EE cert contains a Subject Alternative Name with the dNSName
+    `*.s3.amazonaws.com`. The `s3.amazonaws.com` suffix is listed in the
+    Public Suffix List's PRIVATE DOMAINS section, so per CABF a conformant
+    CA should not issue this certificate and clients should reject it.
+
+    The wildcard here is followed by three labels, so neither a "≥2 labels"
+    nor a "≥3 labels" heuristic suffices to reject it. Doing so correctly
+    requires consulting the PSL (including its private-domains section).
+    """
+    root = builder.root_ca()
+    leaf = builder.leaf_cert(
+        root,
+        san=ext(x509.SubjectAlternativeName([x509.DNSName("*.s3.amazonaws.com")]), critical=False),
+    )
+
+    builder = builder.server_validation().features([Feature.pedantic_public_suffix_wildcard])
+    builder.trusted_certs(root).peer_certificate(leaf).expected_peer_name(
+        PeerName(kind="DNS", value="example.s3.amazonaws.com")
+    ).fails()
+
+
+@testcase
 def leftmost_wildcard_san(builder: Builder) -> None:
     """
     Produces a chain with an EE cert.


### PR DESCRIPTION
I've been chasing down some of the Go stdlib divergences and noticed that it (and `certvalidator`) were curious outliers with unexpected successful verification on [`webpki::san::public-suffix-wildcard-san`](https://x509-limbo.com/testcases/webpki/#webpkisanpublic-suffix-wildcard-san). It seemed surprising that so many other validators were consuming the PSL (it's very annoying to do!), and in particular I knew that `rustls-webpki` certainly doesn't take a dependency on the public suffix data, but was passing this test case.

At least for `rustls-webpki` I think the root cause is that the existing `webpki::san::public-suffix-wildcard-san` test case was using `*.com` as its problematic SAN, and that is trivially detected by a simple heuristic that `rustls-webpki` [claims to have inherited from NSS](https://github.com/rustls/webpki/blob/db6e9206b58609cf55a281a2144bbafb6aa5574b/src/subject_name/dns_name.rs#L514-L520) where we require at least two labels to follow the wildcard label. I suspect other impls are doing similar.

This branch adds two additional PSL wildcard test cases that discriminate real PSL-based validation from a "wildcard must be followed by >=2 labels" heuristic (by testing `*.co.uk`) and more generally from any pure label-count heuristics  (by testing `*.s3.amazonaws.com`, a PSL private-domain entry). I think this will provide better insight into how tightly various implementations are adhering to the CABF requirement.
