### PR TITLE
Fix two testcase typos

### DIFF
--- a/limbo/testcases/webpki/__init__.py
+++ b/limbo/testcases/webpki/__init__.py
@@ -267,7 +267,7 @@ def forbidden_weak_rsa_in_leaf(builder: Builder) -> None:
 
 
 @testcase
-def forbidden_rsa_not_divisable_by_8_in_root(builder: Builder) -> None:
+def forbidden_rsa_not_divisible_by_8_in_root(builder: Builder) -> None:
     """
     Produces the following **invalid** chain:
 
@@ -291,7 +291,7 @@ def forbidden_rsa_not_divisable_by_8_in_root(builder: Builder) -> None:
 
 
 @testcase
-def forbidden_rsa_key_not_divisable_by_8_in_leaf(builder: Builder) -> None:
+def forbidden_rsa_key_not_divisible_by_8_in_leaf(builder: Builder) -> None:
     """
     Produces the following **invalid** chain:
 


### PR DESCRIPTION
Closes #474.

NB this will break PyCA's CI since we currently have a testcase carveout with the old name.