### PR TITLE
Fixup test cases identified in #634

### DIFF
--- a/limbo/testcases/rfc5280/__init__.py
+++ b/limbo/testcases/rfc5280/__init__.py
@@ -301,7 +301,7 @@ def intermediate_ca_missing_basic_constraints(builder: Builder) -> None:
     leaf = builder.leaf_cert(intermediate)
 
     builder = builder.server_validation()
-    builder.trusted_certs(root).peer_certificate(leaf).fails()
+    builder.trusted_certs(root).untrusted_intermediates(intermediate).peer_certificate(leaf).fails()
 
 
 @testcase
@@ -437,7 +437,7 @@ def ica_ku_keycertsign(builder: Builder) -> None:
     leaf = builder.leaf_cert(intermediate)
 
     builder = builder.server_validation()
-    builder.trusted_certs(root).peer_certificate(leaf).fails()
+    builder.trusted_certs(root).untrusted_intermediates(intermediate).peer_certificate(leaf).fails()
 
 
 @testcase

--- a/limbo/testcases/rfc5280/ski.py
+++ b/limbo/testcases/rfc5280/ski.py
@@ -29,7 +29,8 @@ def critical_ski(builder: Builder) -> None:
     leaf = builder.leaf_cert(
         root,
         aki=ext(
-            x509.AuthorityKeyIdentifier.from_issuer_public_key(key.public_key()), critical=False),
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(key.public_key()), critical=False
+        ),
     )
 
     builder = builder.server_validation()

--- a/limbo/testcases/rfc5280/ski.py
+++ b/limbo/testcases/rfc5280/ski.py
@@ -26,7 +26,11 @@ def critical_ski(builder: Builder) -> None:
     root = builder.root_ca(
         ski=ext(x509.SubjectKeyIdentifier.from_public_key(key.public_key()), critical=True),
     )
-    leaf = builder.leaf_cert(root)
+    leaf = builder.leaf_cert(
+        root,
+        aki=ext(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(key.public_key()), critical=False),
+    )
 
     builder = builder.server_validation()
     builder = builder.trusted_certs(root).peer_certificate(leaf).fails()


### PR DESCRIPTION
Add the missing intermediates to two cases, and glue in AKID so the path is correct before SKI criticality is checked.