### PR TITLE
Add nc testcases for an empty permittedSubtrees

### DIFF
--- a/limbo/testcases/rfc5280/nc.py
+++ b/limbo/testcases/rfc5280/nc.py
@@ -718,23 +718,13 @@ def permitted_empty_sequence_excluded_nonempty(builder: Builder) -> None:
     ```
 
     The ICA contains a NameConstraints extension whose permittedSubtrees is
-    present but empty, alongside a non-empty excludedSubtrees of "bad.example".
-    The leaf's SubjectAlternativeName is "example.com", which does not match
-    the excluded subtree.
+    present but empty, alongside an excluded dNSName of "bad.example". The
+    leaf's SubjectAlternativeName is "example.com", which does not match the
+    excluded subtree.
 
-    This is invalid for two independent reasons. First, an empty
-    `GeneralSubtrees` violates the ASN.1 syntax in RFC 5280 4.2.1.10:
+    An empty permittedSubtrees violates RFC 5280 4.2.1.10, and permits nothing:
 
     > GeneralSubtrees ::= SEQUENCE SIZE (1..MAX) OF GeneralSubtree
-
-    Second, even if the encoding is accepted, RFC 5280 6.1.4 (g)(1) intersects
-    the permitted subtree state with the extension's permittedSubtrees, and an
-    intersection with the empty set is empty. RFC 5280 6.1.3 (b) then requires
-    each name to fall within permitted_subtrees, which no name can do once that
-    set is empty, so every certificate below this ICA must be rejected.
-
-    Implementations that only reject a NameConstraints extension when *both*
-    subtree fields are empty will accept this chain.
     """
 
     # NOTE: Set inner attributes directly to bypass validation.
@@ -767,14 +757,8 @@ def permitted_nonempty_excluded_nonempty(builder: Builder) -> None:
 
     The ICA contains a NameConstraints extension with a permitted dNSName of
     "example.com" and an excluded dNSName of "bad.example". The leaf's
-    SubjectAlternativeName matches the permitted subtree and does not match the
-    excluded one.
-
-    This is the control for
-    `rfc5280::nc::permitted-empty-sequence-excluded-nonempty`: the two chains
-    differ only in whether permittedSubtrees is empty, so an implementation that
-    passes here and passes there is accepting the empty case on its merits
-    rather than failing both for an unrelated reason.
+    SubjectAlternativeName matches the permitted subtree and does not match
+    the excluded one.
     """
     root = builder.root_ca()
     ica = builder.intermediate_ca(

--- a/limbo/testcases/rfc5280/nc.py
+++ b/limbo/testcases/rfc5280/nc.py
@@ -709,6 +709,95 @@ def excluded_match_permitted_and_excluded(builder: Builder) -> None:
 
 
 @testcase
+def permitted_empty_sequence_excluded_nonempty(builder: Builder) -> None:
+    """
+    Produces the following **invalid** chain:
+
+    ```
+    root -> ICA -> leaf
+    ```
+
+    The ICA contains a NameConstraints extension whose permittedSubtrees is
+    present but empty, alongside a non-empty excludedSubtrees of "bad.example".
+    The leaf's SubjectAlternativeName is "example.com", which does not match
+    the excluded subtree.
+
+    This is invalid for two independent reasons. First, an empty
+    `GeneralSubtrees` violates the ASN.1 syntax in RFC 5280 4.2.1.10:
+
+    > GeneralSubtrees ::= SEQUENCE SIZE (1..MAX) OF GeneralSubtree
+
+    Second, even if the encoding is accepted, RFC 5280 6.1.4 (g)(1) intersects
+    the permitted subtree state with the extension's permittedSubtrees, and an
+    intersection with the empty set is empty. RFC 5280 6.1.3 (b) then requires
+    each name to fall within permitted_subtrees, which no name can do once that
+    set is empty, so every certificate below this ICA must be rejected.
+
+    Implementations that only reject a NameConstraints extension when *both*
+    subtree fields are empty will accept this chain.
+    """
+
+    # NOTE: Set inner attributes directly to bypass validation.
+    nc = x509.NameConstraints(
+        permitted_subtrees=[x509.DNSName("example.com")], excluded_subtrees=None
+    )
+    nc._permitted_subtrees = []
+    nc._excluded_subtrees = [x509.DNSName("bad.example")]
+
+    root = builder.root_ca()
+    ica = builder.intermediate_ca(root, name_constraints=ext(nc, critical=True))
+    leaf = builder.leaf_cert(
+        ica, san=ext(x509.SubjectAlternativeName([x509.DNSName("example.com")]), critical=False)
+    )
+
+    builder = builder.server_validation()
+    builder.trusted_certs(root).untrusted_intermediates(ica).peer_certificate(
+        leaf
+    ).expected_peer_name(PeerName(kind=PeerKind.DNS, value="example.com")).fails()
+
+
+@testcase
+def permitted_nonempty_excluded_nonempty(builder: Builder) -> None:
+    """
+    Produces the following **valid** chain:
+
+    ```
+    root -> ICA -> leaf
+    ```
+
+    The ICA contains a NameConstraints extension with a permitted dNSName of
+    "example.com" and an excluded dNSName of "bad.example". The leaf's
+    SubjectAlternativeName matches the permitted subtree and does not match the
+    excluded one.
+
+    This is the control for
+    `rfc5280::nc::permitted-empty-sequence-excluded-nonempty`: the two chains
+    differ only in whether permittedSubtrees is empty, so an implementation that
+    passes here and passes there is accepting the empty case on its merits
+    rather than failing both for an unrelated reason.
+    """
+    root = builder.root_ca()
+    ica = builder.intermediate_ca(
+        root,
+        name_constraints=ext(
+            x509.NameConstraints(
+                permitted_subtrees=[x509.DNSName("example.com")],
+                excluded_subtrees=[x509.DNSName("bad.example")],
+            ),
+            critical=True,
+        ),
+    )
+    leaf = builder.leaf_cert(
+        ica, san=ext(x509.SubjectAlternativeName([x509.DNSName("example.com")]), critical=False)
+    )
+
+    builder = builder.server_validation()
+    builder.trusted_certs(root).untrusted_intermediates(ica).peer_certificate(
+        leaf
+    ).expected_peer_name(PeerName(kind=PeerKind.DNS, value="example.com")).succeeds()
+
+
+@testcase
 def permitted_different_constraint_type(builder: Builder) -> None:
     """
     Produces the following **valid** chain:


### PR DESCRIPTION
Adds two `rfc5280::nc` testcases for a `permittedSubtrees` that is present but empty. `webpki::nc::intermediate-permitted-excluded-subtrees-both-empty-sequences` already covers both subtree fields being empty, which an implementation can reject by treating the whole extension as degenerate. Pairing an empty `permittedSubtrees` with a non-empty `excludedSubtrees` closes that shortcut, since the extension still carries a constraint to enforce. `permitted-empty-sequence-excluded-nonempty` is that chain and must be rejected, because an empty permitted set admits no names. `permitted-nonempty-excluded-nonempty` is the same chain with a non-empty `permittedSubtrees` and must validate, which separates accepting the empty case from failing both for an unrelated reason. Split out from pyca/cryptography#15560, where @alex preferred this be covered as an x509-limbo testcase rather than against the Rust APIs; pyca/cryptography 50.0.1 accepts the invalid case today.