### PR TITLE
More email/URI NC test cases

### DIFF
--- a/limbo/testcases/rfc5280/nc.py
+++ b/limbo/testcases/rfc5280/nc.py
@@ -2145,6 +2145,56 @@ def nc_permits_uri_host_rejects_subdomain(builder: Builder) -> None:
 
 
 @testcase
+def nc_permits_uri_subdomains_rejects_apex(builder: Builder) -> None:
+    """
+    Produces the following **invalid** graph:
+
+    ```
+    root -> ICA (permit URI: .example.com) -> EE (SAN: https://example.com)
+    ```
+
+    Per RFC 5280 4.2.1.10, a URI name constraint with a leading period permits
+    hosts with one or more additional labels but not the named host itself. The
+    EE contains a URI on "example.com", alongside a dNSName used for server
+    identification.
+    """
+
+    root = builder.root_ca()
+    ica = builder.intermediate_ca(
+        root,
+        name_constraints=ext(
+            x509.NameConstraints(
+                permitted_subtrees=[x509.UniformResourceIdentifier(".example.com")],
+                excluded_subtrees=None,
+            ),
+            critical=True,
+        ),
+        san=None,
+    )
+    leaf = builder.leaf_cert(
+        ica,
+        san=ext(
+            x509.SubjectAlternativeName(
+                [
+                    x509.DNSName("example.com"),
+                    x509.UniformResourceIdentifier("https://example.com/not-allowed"),
+                ]
+            ),
+            critical=False,
+        ),
+    )
+
+    builder = (
+        builder.server_validation()
+        .trusted_certs(root)
+        .untrusted_intermediates(ica)
+        .peer_certificate(leaf)
+        .expected_peer_name(PeerName(kind=PeerKind.DNS, value="example.com"))
+        .fails()
+    )
+
+
+@testcase
 def nc_forbids_othername(builder: Builder) -> None:
     """
     Produces the following **invalid** graph:

--- a/limbo/testcases/rfc5280/nc.py
+++ b/limbo/testcases/rfc5280/nc.py
@@ -1738,6 +1738,52 @@ def nc_permits_email_domain_rejects_subdomain(builder: Builder) -> None:
 
 
 @testcase
+def nc_permits_email_subdomains_rejects_apex(builder: Builder) -> None:
+    """
+    Produces the following **invalid** graph:
+
+    ```
+    root -> ICA (permit: .example.com) -> EE (SAN: foo@example.com)
+    ```
+
+    Per RFC 5280 4.2.1.10, an email name constraint with a leading period
+    permits mailboxes on subdomains but not on the named host itself. The EE
+    contains an rfc822Name of "foo@example.com", alongside a dNSName used for
+    server identification.
+    """
+
+    root = builder.root_ca()
+    ica = builder.intermediate_ca(
+        root,
+        name_constraints=ext(
+            x509.NameConstraints(
+                permitted_subtrees=[x509.RFC822Name(".example.com")], excluded_subtrees=None
+            ),
+            critical=True,
+        ),
+        san=None,
+    )
+    leaf = builder.leaf_cert(
+        ica,
+        san=ext(
+            x509.SubjectAlternativeName(
+                [x509.DNSName("example.com"), x509.RFC822Name("foo@example.com")]
+            ),
+            critical=False,
+        ),
+    )
+
+    builder = (
+        builder.server_validation()
+        .trusted_certs(root)
+        .untrusted_intermediates(ica)
+        .peer_certificate(leaf)
+        .expected_peer_name(PeerName(kind=PeerKind.DNS, value="example.com"))
+        .fails()
+    )
+
+
+@testcase
 def nc_permits_email_literal_asterisk_exact_match(builder: Builder) -> None:
     """
     Produces the following **valid** graph:


### PR DESCRIPTION
Follow-up to #662 with the mirror cases (suggested by @rolandshoemaker): a leading-period `.example.com` email or URI name constraint must not match the apex `example.com`.